### PR TITLE
保有銘柄のCRUDを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,4 @@ end
 gem 'sorcery'
 gem 'rails-i18n'
 gem 'basic_yahoo_finance'
+gem 'bootstrap_form'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
+    bootstrap_form (5.1.0)
+      actionpack (>= 5.2)
+      activemodel (>= 5.2)
     builder (3.2.4)
     capybara (3.38.0)
       addressable
@@ -321,6 +324,7 @@ DEPENDENCIES
   annotate
   basic_yahoo_finance
   bootsnap
+  bootstrap_form
   capybara
   cssbundling-rails
   debug

--- a/app/controllers/possessions_controller.rb
+++ b/app/controllers/possessions_controller.rb
@@ -32,6 +32,13 @@ class PossessionsController < ApplicationController
     end
   end
 
+  def destroy
+    @possession = current_user.possessions.find(params[:id])
+
+    @possession.destroy!
+    flash.now[:success] = "保有銘柄「#{@possession.stock.name}」を削除しました。"
+  end
+
   private
 
   def possession_params

--- a/app/controllers/possessions_controller.rb
+++ b/app/controllers/possessions_controller.rb
@@ -7,6 +7,10 @@ class PossessionsController < ApplicationController
     @possession = current_user.possessions.build
   end
 
+  def edit
+    @possession = current_user.possessions.find(params[:id])
+  end
+
   def create
     @possession = current_user.possessions.build(possession_params)
 
@@ -15,6 +19,16 @@ class PossessionsController < ApplicationController
       flash.now[:success] = "「#{@possession.stock.name}」を保有銘柄に追加しました。"
     else
       render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @possession = current_user.possessions.find(params[:id])
+
+    if @possession.update(possession_params)
+      flash.now[:success] = "保有銘柄「#{@possession.stock.name}」を更新しました。"
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/possessions_controller.rb
+++ b/app/controllers/possessions_controller.rb
@@ -1,4 +1,26 @@
 class PossessionsController < ApplicationController
   def index
+    @possessions = current_user.possessions.all.order(created_at: :desc)
+  end
+
+  def new
+    @possession = current_user.possessions.build
+  end
+
+  def create
+    @possession = current_user.possessions.build(possession_params)
+
+    if @possession.save
+      @possession.stock.set_prices
+      flash.now[:success] = "「#{@possession.stock.name}」を保有銘柄に追加しました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def possession_params
+    params.require(:possession).permit(:stock_id, :price, :volume, :memo)
   end
 end

--- a/app/controllers/possessions_controller.rb
+++ b/app/controllers/possessions_controller.rb
@@ -1,0 +1,4 @@
+class PossessionsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_back_or_to login_url, success: 'ログインしました。'
+      redirect_back_or_to root_url, success: 'ログインしました。'
     else
       flash.now[:danger] = 'ログインに失敗しました。'
       render :new, status: :unprocessable_entity

--- a/app/models/possession.rb
+++ b/app/models/possession.rb
@@ -7,12 +7,27 @@ class Possession < ApplicationRecord
   validates :price, presence: true, numericality: { greater_than: 0 }
   validates :memo, length: { maximum: 50 }
 
-  def print_stock_totals_and_changes
-    today = self.stock.prices[-1].market_close * self.volume
-    buy = self.price * self.volume
-    change = "#{'+' if today > buy}#{((today - buy) / buy * 100).round(2)}%"
+  def today_price
+    self.stock.prices[-1].market_close
+  end
 
-    "#{today.to_fs(:delimited)}#{self.stock.japanese? ? '円' : '＄'}(#{change})"
+  def price_difference
+    if self.stock.prices.size >= 2
+      today = self.stock.prices[-1].market_close
+      yesterday = self.stock.prices[-2].market_close
+
+      ((today / yesterday) - 1) * 100
+    else
+      0
+    end
+  end
+
+  def total_price
+    today_price * self.volume
+  end
+
+  def total_change
+    ((today_price / self.price) - 1) * 100
   end
 
   private

--- a/app/models/possession.rb
+++ b/app/models/possession.rb
@@ -2,3 +2,26 @@ class Possession < ApplicationRecord
   belongs_to :user
   belongs_to :stock
 end
+
+# == Schema Information
+#
+# Table name: possessions
+#
+#  id         :bigint           not null, primary key
+#  price      :float            not null
+#  volume     :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  stock_id   :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_possessions_on_stock_id  (stock_id)
+#  index_possessions_on_user_id   (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (stock_id => stocks.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/possession.rb
+++ b/app/models/possession.rb
@@ -2,10 +2,24 @@ class Possession < ApplicationRecord
   belongs_to :user
   belongs_to :stock
 
-  validates :stock_id, presence: true
+  validate :stock_id_is_valid
   validates :volume, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :price, presence: true, numericality: { greater_than: 0 }
   validates :memo, length: { maximum: 50 }
+
+  def print_stock_totals_and_changes
+    today = self.stock.prices[-1].market_close * self.volume
+    buy = self.price * self.volume
+    change = "#{'+' if today > buy}#{((today - buy) / buy * 100).round(2)}%"
+
+    "#{today.to_fs(:delimited)}#{self.stock.japanese? ? '円' : '＄'}(#{change})"
+  end
+
+  private
+
+  def stock_id_is_valid
+    errors.add(:stock_id, '一覧から選択してください') unless Stock.find_by(id: stock_id)
+  end
 end
 
 # == Schema Information

--- a/app/models/possession.rb
+++ b/app/models/possession.rb
@@ -1,0 +1,4 @@
+class Possession < ApplicationRecord
+  belongs_to :user
+  belongs_to :stock
+end

--- a/app/models/possession.rb
+++ b/app/models/possession.rb
@@ -1,6 +1,9 @@
 class Possession < ApplicationRecord
   belongs_to :user
   belongs_to :stock
+
+  validates :volume, presence: true
+  validates :price, presence: true
 end
 
 # == Schema Information
@@ -8,6 +11,7 @@ end
 # Table name: possessions
 #
 #  id         :bigint           not null, primary key
+#  memo       :string
 #  price      :float            not null
 #  volume     :integer          not null
 #  created_at :datetime         not null

--- a/app/models/possession.rb
+++ b/app/models/possession.rb
@@ -2,8 +2,10 @@ class Possession < ApplicationRecord
   belongs_to :user
   belongs_to :stock
 
-  validates :volume, presence: true
-  validates :price, presence: true
+  validates :stock_id, presence: true
+  validates :volume, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :price, presence: true, numericality: { greater_than: 0 }
+  validates :memo, length: { maximum: 50 }
 end
 
 # == Schema Information

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -29,6 +29,23 @@ class Stock < ApplicationRecord
 
     prices.update(market_close: data[symbol]['regularMarketDayHigh'])
   end
+
+  def print_stock_prices_and_changes
+    today = self.prices[-1].market_close
+
+    if self.prices.size >= 2
+      yesterday = self.prices[-2].market_close
+      change = "#{'+' if today > yesterday}#{((today - yesterday) / today * 100).round(2)}%"
+    else
+      change = 'NoDATA'
+    end
+
+    "#{today.to_fs(:delimited)}#{self.japanese? ? '円' : '＄'} (#{change})"
+  end
+
+  def japanese?
+    self.category.zero?
+  end
 end
 
 # == Schema Information

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -1,5 +1,6 @@
 class Stock < ApplicationRecord
   has_many :prices, dependent: :destroy
+  has_many :possessions, dependent: :destroy
 
   validates :category, presence: true
   validates :code, presence: true, uniqueness: true

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -30,19 +30,6 @@ class Stock < ApplicationRecord
     prices.update(market_close: data[symbol]['regularMarketDayHigh'])
   end
 
-  def print_stock_prices_and_changes
-    today = self.prices[-1].market_close
-
-    if self.prices.size >= 2
-      yesterday = self.prices[-2].market_close
-      change = "#{'+' if today > yesterday}#{((today - yesterday) / today * 100).round(2)}%"
-    else
-      change = 'NoDATA'
-    end
-
-    "#{today.to_fs(:delimited)}#{self.japanese? ? '円' : '＄'} (#{change})"
-  end
-
   def japanese?
     self.category.zero?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :possessions, dependent: :destroy
+  has_many :stocks, through: :possessions
 
   authenticates_with_sorcery!
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :possessions, dependent: :destroy
+
   authenticates_with_sorcery!
 
   validates :username, presence: true, uniqueness: true

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,9 +25,7 @@
     </div>
     <div class="container">
       <div id="flash">
-        <% flash.each do |message_type, message| %>
-          <%= content_tag :div, message, class: "alert alert-#{message_type}" %>
-        <% end %>
+        <%= render 'shared/flash_messages' %>
       </div>
       <%= yield %>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,9 +24,11 @@
       </div>
     </div>
     <div class="container">
-      <% flash.each do |message_type, message| %>
-        <%= content_tag :div, message, class: "alert alert-#{message_type}" %>
-      <% end %>
+      <div id="flash">
+        <% flash.each do |message_type, message| %>
+          <%= content_tag :div, message, class: "alert alert-#{message_type}" %>
+        <% end %>
+      </div>
       <%= yield %>
     </div>
   </body>

--- a/app/views/possessions/_possession.html.erb
+++ b/app/views/possessions/_possession.html.erb
@@ -15,11 +15,15 @@
       </div>
       <div class="col-2 d-flex justify-content-end">
         <%= number_to_currency(possession.today_price, locale: possession.stock.japanese? ? :ja : :en) %>
-        <%= "(#{'+' if possession.price_difference.positive?}#{number_to_percentage(possession.price_difference, precision: 2)})" %>
+        <div class="<%= possession.price_difference.positive? ? 'text-success' : 'text-danger' %>">
+          <%= "(#{'+' if possession.price_difference.positive?}#{number_to_percentage(possession.price_difference, precision: 2)})" %>
+        </div>
       </div>
       <div class="col-2 d-flex justify-content-end">
         <%= number_to_currency(possession.total_price, locale: possession.stock.japanese? ? :ja : :en) %>
-        <%= "(#{'+' if possession.total_change.positive?}#{number_to_percentage(possession.total_change, precision: 2)})" %>
+        <div class="<%= possession.total_change.positive? ? 'text-success' : 'text-danger' %>">
+          <%= "(#{'+' if possession.total_change.positive?}#{number_to_percentage(possession.total_change, precision: 2)})" %>
+        </div>
       </div>
       <div class="col-2">
         <%= link_to '編集', edit_possession_path(possession), class: 'btn btn-sm btn-primary me-3' %>

--- a/app/views/possessions/_possession.html.erb
+++ b/app/views/possessions/_possession.html.erb
@@ -2,22 +2,24 @@
   <div class="border-bottom">
     <div class="row align-items-center p-2">
       <div class="col-1">
-        <%= possession.stock.category.zero? ? '日本' : '米国' %>
+        <%= possession.stock.japanese? ? '日本' : '米国' %>
       </div>
       <div class="col-3">
         <%= possession.stock.name %>
       </div>
       <div class="col-1 d-flex justify-content-end">
-        <%= possession.volume %>
+        <%= number_with_delimiter(possession.volume) %>
       </div>
       <div class="col-1 d-flex justify-content-end">
-        <%= "#{possession.price}#{possession.stock.japanese? ? '円' : '＄'}" %>
+        <%= number_to_currency(possession.price, locale: possession.stock.japanese? ? :ja : :en) %>
       </div>
       <div class="col-2 d-flex justify-content-end">
-        <%= possession.stock.print_stock_prices_and_changes %>
+        <%= number_to_currency(possession.today_price, locale: possession.stock.japanese? ? :ja : :en) %>
+        <%= "(#{'+' if possession.price_difference.positive?}#{number_to_percentage(possession.price_difference, precision: 2)})" %>
       </div>
       <div class="col-2 d-flex justify-content-end">
-        <%= possession.print_stock_totals_and_changes %>
+        <%= number_to_currency(possession.total_price, locale: possession.stock.japanese? ? :ja : :en) %>
+        <%= "(#{'+' if possession.total_change.positive?}#{number_to_percentage(possession.total_change, precision: 2)})" %>
       </div>
       <div class="col-2">
         <%= link_to '編集', edit_possession_path(possession), class: 'btn btn-sm btn-primary me-3' %>

--- a/app/views/possessions/_possession.html.erb
+++ b/app/views/possessions/_possession.html.erb
@@ -23,7 +23,7 @@
       </div>
       <div class="col-2">
         <%= link_to '編集', edit_possession_path(possession), class: 'btn btn-sm btn-primary me-3' %>
-        <%= link_to '削除', '#', class: 'btn btn-sm btn-danger' %>
+        <%= link_to '削除', possession, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-sm btn-danger' %>
       </div>
       <div class="row p-2">
         <div class="col-1"></div>

--- a/app/views/possessions/_possession.html.erb
+++ b/app/views/possessions/_possession.html.erb
@@ -5,6 +5,7 @@
         <%= possession.stock.japanese? ? '日本' : '米国' %>
       </div>
       <div class="col-3">
+        <%= "(#{possession.stock.code})" %>
         <%= possession.stock.name %>
       </div>
       <div class="col-1 d-flex justify-content-end">

--- a/app/views/possessions/_possession.html.erb
+++ b/app/views/possessions/_possession.html.erb
@@ -1,30 +1,32 @@
-<div class="border-bottom">
-  <div class="row align-items-center p-2">
-    <div class="col-1">
-      <%= possession.stock.category.zero? ? '日本' : '米国' %>
-    </div>
-    <div class="col-3">
-      <%= possession.stock.name %>
-    </div>
-    <div class="col-1 d-flex justify-content-end">
-      <%= possession.volume %>
-    </div>
-    <div class="col-1 d-flex justify-content-end">
-      <%= "#{possession.price}#{possession.stock.japanese? ? '円' : '＄'}" %>
-    </div>
-    <div class="col-2 d-flex justify-content-end">
-      <%= possession.stock.print_stock_prices_and_changes %>
-    </div>
-    <div class="col-2 d-flex justify-content-end">
-      <%= possession.print_stock_totals_and_changes %>
-    </div>
-    <div class="col-2">
-      <%= link_to '編集', '#', class: 'btn btn-sm btn-primary me-3' %>
-      <%= link_to '削除', '#', class: 'btn btn-sm btn-danger' %>
-    </div>
-    <div class="row p-2">
-      <div class="col-1"></div>
-      <div class="col-11">メモ: <%= possession.memo %></div>
+<%= turbo_frame_tag possession do %>
+  <div class="border-bottom">
+    <div class="row align-items-center p-2">
+      <div class="col-1">
+        <%= possession.stock.category.zero? ? '日本' : '米国' %>
+      </div>
+      <div class="col-3">
+        <%= possession.stock.name %>
+      </div>
+      <div class="col-1 d-flex justify-content-end">
+        <%= possession.volume %>
+      </div>
+      <div class="col-1 d-flex justify-content-end">
+        <%= "#{possession.price}#{possession.stock.japanese? ? '円' : '＄'}" %>
+      </div>
+      <div class="col-2 d-flex justify-content-end">
+        <%= possession.stock.print_stock_prices_and_changes %>
+      </div>
+      <div class="col-2 d-flex justify-content-end">
+        <%= possession.print_stock_totals_and_changes %>
+      </div>
+      <div class="col-2">
+        <%= link_to '編集', edit_possession_path(possession), class: 'btn btn-sm btn-primary me-3' %>
+        <%= link_to '削除', '#', class: 'btn btn-sm btn-danger' %>
+      </div>
+      <div class="row p-2">
+        <div class="col-1"></div>
+        <div class="col-9">メモ: <%= possession.memo %></div>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/possessions/_possession.html.erb
+++ b/app/views/possessions/_possession.html.erb
@@ -1,0 +1,30 @@
+<div class="border-bottom">
+  <div class="row align-items-center p-2">
+    <div class="col-1">
+      <%= possession.stock.category.zero? ? '日本' : '米国' %>
+    </div>
+    <div class="col-3">
+      <%= possession.stock.name %>
+    </div>
+    <div class="col-1 d-flex justify-content-end">
+      <%= possession.volume %>
+    </div>
+    <div class="col-1 d-flex justify-content-end">
+      <%= "#{possession.price}#{possession.stock.japanese? ? '円' : '＄'}" %>
+    </div>
+    <div class="col-2 d-flex justify-content-end">
+      <%= possession.stock.print_stock_prices_and_changes %>
+    </div>
+    <div class="col-2 d-flex justify-content-end">
+      <%= possession.print_stock_totals_and_changes %>
+    </div>
+    <div class="col-2">
+      <%= link_to '編集', '#', class: 'btn btn-sm btn-primary me-3' %>
+      <%= link_to '削除', '#', class: 'btn btn-sm btn-danger' %>
+    </div>
+    <div class="row p-2">
+      <div class="col-1"></div>
+      <div class="col-11">メモ: <%= possession.memo %></div>
+    </div>
+  </div>
+</div>

--- a/app/views/possessions/create.turbo_stream.erb
+++ b/app/views/possessions/create.turbo_stream.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream.prepend 'possessions', @possession %>
+
 <%= turbo_stream.update 'new_possession', "" %>
 
 <%= turbo_stream.update 'flash' do %>

--- a/app/views/possessions/create.turbo_stream.erb
+++ b/app/views/possessions/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update 'new_possession', "" %>
+
+<%= turbo_stream.update 'flash' do %>
+  <% flash.each do |message_type, message| %>
+    <%= content_tag :div, message, class: "alert alert-#{message_type}" %>
+  <% end %>
+<% end %>

--- a/app/views/possessions/create.turbo_stream.erb
+++ b/app/views/possessions/create.turbo_stream.erb
@@ -3,7 +3,5 @@
 <%= turbo_stream.update 'new_possession', "" %>
 
 <%= turbo_stream.update 'flash' do %>
-  <% flash.each do |message_type, message| %>
-    <%= content_tag :div, message, class: "alert alert-#{message_type}" %>
-  <% end %>
+  <%= render 'shared/flash_messages' %>
 <% end %>

--- a/app/views/possessions/destroy.turbo_stream.erb
+++ b/app/views/possessions/destroy.turbo_stream.erb
@@ -1,7 +1,5 @@
 <%= turbo_stream.remove @possession %>
 
 <%= turbo_stream.update 'flash' do %>
-  <% flash.each do |message_type, message| %>
-    <%= content_tag :div, message, class: "alert alert-#{message_type}" %>
-  <% end %>
+  <%= render 'shared/flash_messages' %>
 <% end %>

--- a/app/views/possessions/destroy.turbo_stream.erb
+++ b/app/views/possessions/destroy.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.remove @possession %>
+
+<%= turbo_stream.update 'flash' do %>
+  <% flash.each do |message_type, message| %>
+    <%= content_tag :div, message, class: "alert alert-#{message_type}" %>
+  <% end %>
+<% end %>

--- a/app/views/possessions/edit.html.erb
+++ b/app/views/possessions/edit.html.erb
@@ -1,0 +1,30 @@
+<%= turbo_frame_tag @possession do %>
+  <%= bootstrap_form_with model: @possession do |f| %>
+    <div class="row p-2">
+      <div class="col-1"><%= @possession.stock.japanese? ? '日本' : '米国' %></div>
+      <div class="col-3">
+        <%= @possession.stock.name %>
+      </div>
+      <div class="col-2">
+        <%= f.number_field :volume, min: 1, skip_label: true, label_as_placeholder: true, wrapper: false, control_class: 'form-control' %>
+      </div>
+      <div class="col-2">
+        <%= f.number_field :price, min: 0, step: 0.1, skip_label: true, label_as_placeholder: true, wrapper: false, control_class: 'form-control' %>
+      </div>
+      <div class="col-1"></div>
+      <div class="col-1"></div>
+      <div class="col-2">
+        <%= f.submit class: 'btn btn-primary' %>
+      </div>
+    </div>
+    <div class="row p-2 border-bottom">
+      <div class="col-1"></div>
+      <div class="col-9">
+        <%= f.text_field :memo, maxlength: 50, skip_label: true, label_as_placeholder: true, wrapper: false, control_class: 'form-control' %>
+      </div>
+      <div class="col-2">
+        <%= link_to 'キャンセル', possessions_path, class: 'btn btn-outline-secondary' %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/possessions/edit.html.erb
+++ b/app/views/possessions/edit.html.erb
@@ -14,7 +14,7 @@
       <div class="col-1"></div>
       <div class="col-1"></div>
       <div class="col-2">
-        <%= f.submit class: 'btn btn-primary' %>
+        <%= f.submit class: 'btn btn-sm btn-primary' %>
       </div>
     </div>
     <div class="row p-2 border-bottom">
@@ -23,7 +23,7 @@
         <%= f.text_field :memo, maxlength: 50, skip_label: true, label_as_placeholder: true, wrapper: false, control_class: 'form-control' %>
       </div>
       <div class="col-2">
-        <%= link_to 'キャンセル', possessions_path, class: 'btn btn-outline-secondary' %>
+        <%= link_to 'キャンセル', possessions_path, class: 'btn btn-sm btn-outline-secondary' %>
       </div>
     </div>
   <% end %>

--- a/app/views/possessions/index.html.erb
+++ b/app/views/possessions/index.html.erb
@@ -4,12 +4,21 @@
 
 <div class="card shadow mt-3">
   <div class="card-header">
-    <p>保有銘柄の明細</p>
+    <div class="row">
+      <div class="col-1"><%= Stock.human_attribute_name(:category) %></div>
+      <div class="col-3"><%= Possession.human_attribute_name(:stock_id) %></div>
+      <div class="col-1"><%= Possession.human_attribute_name(:volume) %></div>
+      <div class="col-1"><%= Possession.human_attribute_name(:price) %></div>
+      <div class="col-2"><%= "#{Price.human_attribute_name(:market_close)}(前日比)" %></div>
+      <div class="col-2">評価額(騰落率)</div>
+      <div class="col-2"></div>
+    </div>
   </div>
 
   <div class="card-body">
     <%= turbo_frame_tag 'new_possession' %>
     <div id="possessions">
+      <%= render @possessions %>
     </div>
   </div>
 </div>

--- a/app/views/possessions/index.html.erb
+++ b/app/views/possessions/index.html.erb
@@ -1,2 +1,15 @@
-<h1>Possessions#index</h1>
-<p>Find me in app/views/possessions/index.html.erb</p>
+<h1>保有銘柄一覧</h1>
+
+<%= link_to '＋新規登録', new_possession_path, data: { turbo_frame: 'new_possession' }, class: 'btn btn-primary' %>
+
+<div class="card shadow mt-3">
+  <div class="card-header">
+    <p>保有銘柄の明細</p>
+  </div>
+
+  <div class="card-body">
+    <%= turbo_frame_tag 'new_possession' %>
+    <div id="possessions">
+    </div>
+  </div>
+</div>

--- a/app/views/possessions/index.html.erb
+++ b/app/views/possessions/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Possessions#index</h1>
+<p>Find me in app/views/possessions/index.html.erb</p>

--- a/app/views/possessions/new.html.erb
+++ b/app/views/possessions/new.html.erb
@@ -1,0 +1,24 @@
+<%= turbo_frame_tag 'new_possession' do %>
+  <%= bootstrap_form_with model: @possession do |f| %>
+    <div class="row">
+      <div class="form-group col-5">
+        <%= f.collection_select :stock_id, Stock.all, :id, ->(stock) { "#{stock.code}:#{stock.name}" }, prompt: '選択してください' %>
+      </div>
+      <div class="form-group col-2">
+        <%= f.number_field :price, min: 0, step: 0.1 %>
+      </div>
+      <div class="form-group col-2">
+        <%= f.number_field :volume, min: 1 %>
+      </div>
+    </div>
+    <div class="row pb-5 mb-3 border-bottom">
+      <div class="form-group col-9">
+        <%= f.text_field :memo, maxlength: 50, help: 'メモは50文字まで入力できます。' %>
+      </div>
+      <div class="col-3 d-flex justify-content-center align-items-start">
+        <%= f.submit class: 'btn btn btn-primary me-3' %>
+        <%= link_to 'キャンセル', possessions_path, class: 'btn btn btn-outline-secondary' %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/possessions/update.turbo_stream.erb
+++ b/app/views/possessions/update.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update @possession %>
+
+<%= turbo_stream.update 'flash' do %>
+  <% flash.each do |message_type, message| %>
+    <%= content_tag :div, message, class: "alert alert-#{message_type}" %>
+  <% end %>
+<% end %>

--- a/app/views/possessions/update.turbo_stream.erb
+++ b/app/views/possessions/update.turbo_stream.erb
@@ -1,7 +1,5 @@
 <%= turbo_stream.update @possession %>
 
 <%= turbo_stream.update 'flash' do %>
-  <% flash.each do |message_type, message| %>
-    <%= content_tag :div, message, class: "alert alert-#{message_type}" %>
-  <% end %>
+  <%= render 'shared/flash_messages' %>
 <% end %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,3 @@
+<% flash.each do |message_type, message| %>
+  <%= content_tag :div, message, class: "alert alert-#{message_type}" %>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       user: ユーザー
+      possession: 保有銘柄
     attributes:
       user:
         id: ID
@@ -12,3 +13,9 @@ ja:
         password_confirmation: パスワード（確認）
         created_at: 登録日時
         updated_at: 更新日時
+      possession:
+        stock_id: 銘柄
+        id: ID
+        price: 購入価格
+        volume: 数量
+        memo: メモ

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,3 +19,7 @@ ja:
         price: 購入価格
         volume: 数量
         memo: メモ
+      price:
+        market_close: 現在価格
+      stock:
+        category: 分類

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'possessions/index'
   get 'login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
-  get 'possessions/index'
+  root to: 'possessions#index'
+
   get 'login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'
+
   resources :users, except: %i(index)
+  resources :possessions, except: %i(show)
 end

--- a/db/migrate/20230222034422_create_possessions.rb
+++ b/db/migrate/20230222034422_create_possessions.rb
@@ -5,6 +5,7 @@ class CreatePossessions < ActiveRecord::Migration[7.0]
       t.references :stock, null: false, foreign_key: true
       t.integer :volume, null: false
       t.float :price, null: false
+      t.string :memo
 
       t.timestamps
     end

--- a/db/migrate/20230222034422_create_possessions.rb
+++ b/db/migrate/20230222034422_create_possessions.rb
@@ -3,8 +3,8 @@ class CreatePossessions < ActiveRecord::Migration[7.0]
     create_table :possessions do |t|
       t.references :user, null: false, foreign_key: true
       t.references :stock, null: false, foreign_key: true
-      t.integer :volume
-      t.float :price
+      t.integer :volume, null: false
+      t.float :price, null: false
 
       t.timestamps
     end

--- a/db/migrate/20230222034422_create_possessions.rb
+++ b/db/migrate/20230222034422_create_possessions.rb
@@ -1,0 +1,12 @@
+class CreatePossessions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :possessions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :stock, null: false, foreign_key: true
+      t.integer :volume
+      t.float :price
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_22_034422) do
     t.bigint "stock_id", null: false
     t.integer "volume", null: false
     t.float "price", null: false
+    t.string "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["stock_id"], name: "index_possessions_on_stock_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_21_145215) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_22_034422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "possessions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "stock_id", null: false
+    t.integer "volume", null: false
+    t.float "price", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["stock_id"], name: "index_possessions_on_stock_id"
+    t.index ["user_id"], name: "index_possessions_on_user_id"
+  end
 
   create_table "prices", force: :cascade do |t|
     t.bigint "stock_id", null: false
@@ -50,5 +61,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_21_145215) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "possessions", "stocks"
+  add_foreign_key "possessions", "users"
   add_foreign_key "prices", "stocks"
 end

--- a/spec/factories/possessions.rb
+++ b/spec/factories/possessions.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :possession do
-    user { nil }
-    stock { nil }
-    volume { 1 }
-    price { 1.5 }
+    user
+    stock
+    volume { rand(1..10) }
+    price { rand(1..100) }
   end
 end
 

--- a/spec/factories/possessions.rb
+++ b/spec/factories/possessions.rb
@@ -6,3 +6,26 @@ FactoryBot.define do
     price { 1.5 }
   end
 end
+
+# == Schema Information
+#
+# Table name: possessions
+#
+#  id         :bigint           not null, primary key
+#  price      :float            not null
+#  volume     :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  stock_id   :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_possessions_on_stock_id  (stock_id)
+#  index_possessions_on_user_id   (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (stock_id => stocks.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/spec/factories/possessions.rb
+++ b/spec/factories/possessions.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     stock
     volume { rand(1..10) }
     price { rand(1..100) }
+    memo { 'text' }
   end
 end
 
@@ -12,6 +13,7 @@ end
 # Table name: possessions
 #
 #  id         :bigint           not null, primary key
+#  memo       :string
 #  price      :float            not null
 #  volume     :integer          not null
 #  created_at :datetime         not null

--- a/spec/factories/possessions.rb
+++ b/spec/factories/possessions.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :possession do
+    user { nil }
+    stock { nil }
+    volume { 1 }
+    price { 1.5 }
+  end
+end

--- a/spec/models/possession_spec.rb
+++ b/spec/models/possession_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Possession, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/possession_spec.rb
+++ b/spec/models/possession_spec.rb
@@ -1,7 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Possession, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    it '数量は必須であること' do
+      possession = build(:possession, volume: nil)
+      possession.valid?
+      expect(possession.errors[:volume]).to include('を入力してください')
+    end
+
+    it '価格は必須であること' do
+      possession = build(:possession, price: nil)
+      possession.valid?
+      expect(possession.errors[:price]).to include('を入力してください')
+    end
+  end
 end
 
 # == Schema Information

--- a/spec/models/possession_spec.rb
+++ b/spec/models/possession_spec.rb
@@ -3,3 +3,26 @@ require 'rails_helper'
 RSpec.describe Possession, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end
+
+# == Schema Information
+#
+# Table name: possessions
+#
+#  id         :bigint           not null, primary key
+#  price      :float            not null
+#  volume     :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  stock_id   :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_possessions_on_stock_id  (stock_id)
+#  index_possessions_on_user_id   (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (stock_id => stocks.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/spec/models/possession_spec.rb
+++ b/spec/models/possession_spec.rb
@@ -21,6 +21,7 @@ end
 # Table name: possessions
 #
 #  id         :bigint           not null, primary key
+#  memo       :string
 #  price      :float            not null
 #  volume     :integer          not null
 #  created_at :datetime         not null


### PR DESCRIPTION
# Issue
#4 
# 概要
保有銘柄のCRUDを一通り実装した。
- 登録
- 編集
- 削除
- 一覧表示
保有銘柄はアプリにあらかじめ登録している株式から、一覧で選択して登録できるようにしている。
CRUDの動作はTurboを活用してページ遷移なしで行えるようにした。
# やり残した点
登録する銘柄を一覧から選ぶようにしているが、数が多いため探すのが大変である。
一応キーボードで頭文字や数字を打ち込めばカーソルは当たるが、利便性を考えると部分一致などでも検索ができるようにしたい。

銘柄の登録が多くなった場合に備えて、一覧をページングできるようにしたい。

一覧の検索、ソートができるようにしたい。