### PR TITLE
株価の定期取得処理

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,4 @@ gem 'sorcery'
 gem 'rails-i18n'
 gem 'basic_yahoo_finance'
 gem 'bootstrap_form'
+gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chronic (0.10.2)
     concurrent-ruby (1.2.0)
     crass (1.0.6)
     cssbundling-rails (1.1.2)
@@ -312,6 +313,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.6)
@@ -350,6 +353,7 @@ DEPENDENCIES
   tzinfo-data
   web-console
   webdrivers
+  whenever
 
 RUBY VERSION
    ruby 3.1.0p0

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -17,7 +17,7 @@ class Stock < ApplicationRecord
       market_open: data[symbol]['regularMarketOpen'],
       daily_high: data[symbol]['regularMarketDayHigh'],
       daily_low: data[symbol]['regularMarketDayLow'],
-      market_close: data[symbol]['regularMarketDayHigh']
+      market_close: data[symbol]['regularMarketPrice']
     )
   end
 
@@ -27,7 +27,7 @@ class Stock < ApplicationRecord
     query = BasicYahooFinance::Query.new
     data = query.quotes(symbol)
 
-    prices.update(market_close: data[symbol]['regularMarketDayHigh'])
+    prices.last.update(market_close: data[symbol]['regularMarketPrice'])
   end
 
   def japanese?

--- a/app/views/possessions/_possession.html.erb
+++ b/app/views/possessions/_possession.html.erb
@@ -19,6 +19,7 @@
         <div class="<%= possession.price_difference.positive? ? 'text-success' : 'text-danger' %>">
           <%= "(#{'+' if possession.price_difference.positive?}#{number_to_percentage(possession.price_difference, precision: 2)})" %>
         </div>
+        <%= possession.stock.prices.last.date %>
       </div>
       <div class="col-2 d-flex justify-content-end">
         <%= number_to_currency(possession.total_price, locale: possession.stock.japanese? ? :ja : :en) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,7 @@ module InvestApp
 
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
+    config.time_zone = 'Asia/Tokyo'
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,20 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -18,3 +18,25 @@
 # end
 
 # Learn more: http://github.com/javan/whenever
+
+# at: の時間指定を24時間形式にする
+set :chronic_options, hours24: true
+
+# 下の方でlogを出力するフォルダを指定する際に、Rails.rootを使うために読み込む
+require File.expand_path(File.dirname(__FILE__) + '/environment')
+
+# RAILS_ENVが指定されていなければdevelopment環境として実行したい。
+rails_env = ENV['RAILS_ENV'] || :development
+
+set :environment, rails_env
+
+# ログの出力先を指定
+set :output, "#{Rails.root}/log/cron.log"
+
+every :weekday, at: ['9:00', '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00'] do
+  rake "stock_prices:update_ja"
+end
+
+every :weekday, at: ['22:30', '23:30', '0:30', '1:30', '2:30', '3:30', '4:30', '5:30', '6:30'] do
+  rake "stock_prices:update_us"
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -33,6 +33,8 @@ set :environment, rails_env
 # ログの出力先を指定
 set :output, "#{Rails.root}/log/cron.log"
 
+job_type :rake, "export PATH=\"/opt/homebrew/bin:$PATH\"; eval \"$(rbenv init -)\"; cd :path && RAILS_ENV=:environment bundle exec rake :task :output"
+
 every :weekday, at: ['9:00', '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00'] do
   rake "stock_prices:update_ja"
 end

--- a/lib/tasks/stock_prices.rake
+++ b/lib/tasks/stock_prices.rake
@@ -1,0 +1,37 @@
+namespace :stock_prices do
+  desc '日本の株価情報を取得する'
+  task update_jp: :environment do
+    # 株価を取得する銘柄を取得
+    stock_ids = Possession.select(:stock_id).distinct.pluck(:stock_id)
+    stocks = Stock.where(id: stock_ids, category: 0)
+
+    stocks.each do |stock|
+      if stock.prices.last.date < Time.zone.today
+        # 今日の株価が未取得なら、DBに登録する
+        stock.set_prices
+      else
+        # 今日の株価が取得済みなら、DBを更新する
+        stock.update_prices
+      end
+      sleep(1)
+    end
+  end
+
+  desc '米国の株価情報を取得する'
+  task update_us: :environment do
+    # 株価を取得する銘柄を取得
+    stock_ids = Possession.select(:stock_id).distinct.pluck(:stock_id)
+    stocks = Stock.where(id: stock_ids, category: 1)
+
+    stocks.each do |stock|
+      if stock.prices.last.date < Time.zone.today
+        # 今日の株価が未取得なら、DBに登録する
+        stock.set_prices
+      else
+        # 今日の株価が取得済みなら、DBを更新する
+        stock.update_prices
+      end
+      sleep(1)
+    end
+  end
+end

--- a/lib/tasks/stock_prices.rake
+++ b/lib/tasks/stock_prices.rake
@@ -3,29 +3,19 @@ namespace :stock_prices do
   task update_jp: :environment do
     # 株価を取得する銘柄を取得
     stock_ids = Possession.select(:stock_id).distinct.pluck(:stock_id)
-    stocks = Stock.where(id: stock_ids, category: 0)
-
-    stocks.each do |stock|
-      if stock.prices.last.date < Time.zone.today
-        # 今日の株価が未取得なら、DBに登録する
-        stock.set_prices
-      else
-        # 今日の株価が取得済みなら、DBを更新する
-        stock.update_prices
-      end
-      sleep(1)
-    end
+    update_prices(stock_ids, 0)
   end
 
   desc '米国の株価情報を取得する'
   task update_us: :environment do
     # 株価を取得する銘柄を取得
     stock_ids = Possession.select(:stock_id).distinct.pluck(:stock_id)
-    stocks = Stock.where(id: stock_ids, category: 1)
+    update_prices(stock_ids, 1)
+  end
 
-    # 日本時間の夜間でDBのレコードが切り替わらないようにUTCで実行する
+  def update_prices(stock_ids, category)
     Time.use_zone('UTC') do
-      stocks.each do |stock|
+      Stock.where(id: stock_ids, category:).find_each do |stock|
         if stock.prices.last.date < Time.zone.today
           # 今日の株価が未取得なら、DBに登録する
           stock.set_prices

--- a/lib/tasks/stock_prices.rake
+++ b/lib/tasks/stock_prices.rake
@@ -23,15 +23,18 @@ namespace :stock_prices do
     stock_ids = Possession.select(:stock_id).distinct.pluck(:stock_id)
     stocks = Stock.where(id: stock_ids, category: 1)
 
-    stocks.each do |stock|
-      if stock.prices.last.date < Time.zone.today
-        # 今日の株価が未取得なら、DBに登録する
-        stock.set_prices
-      else
-        # 今日の株価が取得済みなら、DBを更新する
-        stock.update_prices
+    # 日本時間の夜間でDBのレコードが切り替わらないようにUTCで実行する
+    Time.use_zone('UTC') do
+      stocks.each do |stock|
+        if stock.prices.last.date < Time.zone.today
+          # 今日の株価が未取得なら、DBに登録する
+          stock.set_prices
+        else
+          # 今日の株価が取得済みなら、DBを更新する
+          stock.update_prices
+        end
+        sleep(1)
       end
-      sleep(1)
     end
   end
 end


### PR DESCRIPTION
# Issue
#23 
# 概要
保有銘柄として登録されている銘柄は、定期的に株価を取得しDBを更新する
ひとまず1Hに一度取得する設定にしている。

定期的に実行する仕組みとしては、wheneverというgemを使用して、cronジョブとして登録し実行される。
設定幅は毎分〜年に1回など、細かく指定が可能。
cronはUNIX系OSで定期処理を行う仕組みだが、Herokuなどのプラットフォームによっては使用できないため、別の方法を考える必要あり。