### PR TITLE
ユーザーの総資産額の計算

### DIFF
--- a/app/controllers/possessions_controller.rb
+++ b/app/controllers/possessions_controller.rb
@@ -2,7 +2,7 @@ class PossessionsController < ApplicationController
   before_action :require_login
 
   def index
-    @possessions = current_user.possessions.all.includes(:stock).order(created_at: :desc)
+    @possessions = current_user.possessions.all.includes(stock: :prices).order(created_at: :desc)
   end
 
   def new

--- a/app/models/possession.rb
+++ b/app/models/possession.rb
@@ -26,6 +26,13 @@ class Possession < ApplicationRecord
     today_price * self.volume
   end
 
+  def total_price_to_jpy
+    jpy = Stock.find_by(code: 'JPY=X')
+    jpy.set_prices if jpy.prices.where(date: Time.zone.today).blank?
+
+    total_price * jpy.prices.last.market_close
+  end
+
   def total_change
     ((today_price / self.price) - 1) * 100
   end

--- a/app/models/possession.rb
+++ b/app/models/possession.rb
@@ -8,15 +8,15 @@ class Possession < ApplicationRecord
   validates :memo, length: { maximum: 50 }
 
   def today_price
-    self.stock.prices[-1].market_close
+    self.stock.prices.order(date: :desc).first.market_close
   end
 
   def price_difference
     if self.stock.prices.size >= 2
-      today = self.stock.prices[-1].market_close
-      yesterday = self.stock.prices[-2].market_close
+      prices = self.stock.prices.order(date: :desc)
+      yesterday = prices[1].market_close
 
-      ((today / yesterday) - 1) * 100
+      ((today_price / yesterday) - 1) * 100
     else
       0
     end

--- a/app/models/possession.rb
+++ b/app/models/possession.rb
@@ -30,7 +30,7 @@ class Possession < ApplicationRecord
     jpy = Stock.find_by(code: 'JPY=X')
     jpy.set_prices if jpy.prices.where(date: Time.zone.today).blank?
 
-    total_price * jpy.prices.last.market_close
+    total_price * jpy.prices.order(date: :desc).first.market_close
   end
 
   def total_change

--- a/app/models/total_asset.rb
+++ b/app/models/total_asset.rb
@@ -1,5 +1,8 @@
 class TotalAsset < ApplicationRecord
   belongs_to :user
+
+  validates :date, presence: true, uniqueness: { scope: :user_id }
+  validates :price, presence: true
 end
 
 # == Schema Information

--- a/app/models/total_asset.rb
+++ b/app/models/total_asset.rb
@@ -18,8 +18,8 @@ end
 #
 # Indexes
 #
-#  index_total_assets_on_date     (date) UNIQUE
-#  index_total_assets_on_user_id  (user_id)
+#  index_total_assets_on_user_id           (user_id)
+#  index_total_assets_on_user_id_and_date  (user_id,date) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/total_asset.rb
+++ b/app/models/total_asset.rb
@@ -1,0 +1,3 @@
+class TotalAsset < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/total_asset.rb
+++ b/app/models/total_asset.rb
@@ -1,3 +1,24 @@
 class TotalAsset < ApplicationRecord
   belongs_to :user
 end
+
+# == Schema Information
+#
+# Table name: total_assets
+#
+#  id         :bigint           not null, primary key
+#  date       :date             not null
+#  price      :float            not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_total_assets_on_date     (date) UNIQUE
+#  index_total_assets_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :possessions, dependent: :destroy
   has_many :stocks, through: :possessions
+  has_many :total_assets, dependent: :destroy
 
   authenticates_with_sorcery!
 
@@ -9,6 +10,19 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+
+  def calculate_total_asset
+    total_asset = self.possessions.includes(stock: :prices).sum do |possession|
+      if possession.stock.japanese?
+        possession.total_price
+      else
+        possession.total_price_to_jpy
+      end
+    end
+
+    today_record = self.total_assets.find_or_create_by(date: Time.zone.today)
+    today_record.update(price: total_asset) if today_record.price != total_asset
+  end
 end
 
 # == Schema Information

--- a/app/views/possessions/_possession.html.erb
+++ b/app/views/possessions/_possession.html.erb
@@ -19,7 +19,7 @@
         <div class="<%= possession.price_difference.positive? ? 'text-success' : 'text-danger' %>">
           <%= "(#{'+' if possession.price_difference.positive?}#{number_to_percentage(possession.price_difference, precision: 2)})" %>
         </div>
-        <%= possession.stock.prices.last.date %>
+        <%= possession.stock.prices.order(date: :desc).first.date %>
       </div>
       <div class="col-2 d-flex justify-content-end">
         <%= number_to_currency(possession.total_price, locale: possession.stock.japanese? ? :ja : :en) %>

--- a/app/views/possessions/index.html.erb
+++ b/app/views/possessions/index.html.erb
@@ -1,24 +1,34 @@
-<h1>保有銘柄一覧</h1>
+<div class="row justify-content-center p-5 bg-light">
+  <div class="col">
+    <h1 class="text-center">保有銘柄一覧</h1>
 
-<%= link_to '＋新規登録', new_possession_path, data: { turbo_frame: 'new_possession' }, class: 'btn btn-primary' %>
+    <%= link_to '＋新規登録', new_possession_path, data: { turbo_frame: 'new_possession' }, class: 'btn btn-primary' %>
 
-<div class="card shadow mt-3">
-  <div class="card-header">
-    <div class="row">
-      <div class="col-1"><%= Stock.human_attribute_name(:category) %></div>
-      <div class="col-3"><%= Possession.human_attribute_name(:stock_id) %></div>
-      <div class="col-1"><%= Possession.human_attribute_name(:volume) %></div>
-      <div class="col-1"><%= Possession.human_attribute_name(:price) %></div>
-      <div class="col-2"><%= "#{Price.human_attribute_name(:market_close)}(前日比)" %></div>
-      <div class="col-2">評価額(騰落率)</div>
-      <div class="col-2"></div>
-    </div>
-  </div>
+    <div class="card shadow mt-3">
+      <div class="card-header">
+        <div class="row">
+          <div class="col-1"><%= Stock.human_attribute_name(:category) %></div>
+          <div class="col-3"><%= Possession.human_attribute_name(:stock_id) %></div>
+          <div class="col-1"><%= Possession.human_attribute_name(:volume) %></div>
+          <div class="col-1"><%= Possession.human_attribute_name(:price) %></div>
+          <div class="col-2"><%= "#{Price.human_attribute_name(:market_close)}(前日比)" %></div>
+          <div class="col-2">評価額(騰落率)</div>
+          <div class="col-2"></div>
+        </div>
+      </div>
 
-  <div class="card-body">
-    <%= turbo_frame_tag 'new_possession' %>
-    <div id="possessions">
-      <%= render @possessions %>
+      <div class="card-body">
+        <%= turbo_frame_tag 'new_possession' %>
+        <div id="possessions">
+          <%= render @possessions %>
+        </div>
+        <div class="row p-2">
+          <div class="col d-flex justify-content-center align-items-center">
+            <div class="h3">保有総額 <%= number_to_currency(current_user.total_assets.last.price) %></div>
+            <div class="h6 text-secondary ms-1">(<%= current_user.total_assets.last.date %> 22:00時点)</div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -42,3 +42,7 @@ end
 every :weekday, at: ['22:30', '23:30', '0:30', '1:30', '2:30', '3:30', '4:30', '5:30', '6:30'] do
   rake "stock_prices:update_us"
 end
+
+every 1.day, at: '22:00' do
+  rake "user:calculate_total_asset"
+end

--- a/db/migrate/20230329032421_create_total_assets.rb
+++ b/db/migrate/20230329032421_create_total_assets.rb
@@ -1,0 +1,11 @@
+class CreateTotalAssets < ActiveRecord::Migration[7.0]
+  def change
+    create_table :total_assets do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :date
+      t.float :price
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230329032421_create_total_assets.rb
+++ b/db/migrate/20230329032421_create_total_assets.rb
@@ -2,8 +2,8 @@ class CreateTotalAssets < ActiveRecord::Migration[7.0]
   def change
     create_table :total_assets do |t|
       t.references :user, null: false, foreign_key: true
-      t.date :date
-      t.float :price
+      t.date :date, null: false, index: { unique: true }
+      t.float :price, null: false
 
       t.timestamps
     end

--- a/db/migrate/20230329032421_create_total_assets.rb
+++ b/db/migrate/20230329032421_create_total_assets.rb
@@ -2,10 +2,11 @@ class CreateTotalAssets < ActiveRecord::Migration[7.0]
   def change
     create_table :total_assets do |t|
       t.references :user, null: false, foreign_key: true
-      t.date :date, null: false, index: { unique: true }
+      t.date :date, null: false
       t.float :price, null: false
 
       t.timestamps
+      t.index [:user_id, :date], unique: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,7 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_032421) do
     t.float "price", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["date"], name: "index_total_assets_on_date", unique: true
+    t.index ["user_id", "date"], name: "index_total_assets_on_user_id_and_date", unique: true
     t.index ["user_id"], name: "index_total_assets_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_22_034422) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_29_032421) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_22_034422) do
     t.index ["code"], name: "index_stocks_on_code", unique: true
   end
 
+  create_table "total_assets", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "date", null: false
+    t.float "price", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["date"], name: "index_total_assets_on_date", unique: true
+    t.index ["user_id"], name: "index_total_assets_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "username", null: false
     t.string "email", null: false
@@ -65,4 +75,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_22_034422) do
   add_foreign_key "possessions", "stocks"
   add_foreign_key "possessions", "users"
   add_foreign_key "prices", "stocks"
+  add_foreign_key "total_assets", "users"
 end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,0 +1,9 @@
+namespace :user do
+  desc 'ユーザーの総資産を計算'
+  task calculate_total_asset: :environment do
+    Stock.find_by(code: 'JPY=X').set_prices
+    User.joins(:possessions).distinct.find_each do |user|
+      user.calculate_total_asset
+    end
+  end
+end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -2,8 +2,6 @@ namespace :user do
   desc 'ユーザーの総資産を計算'
   task calculate_total_asset: :environment do
     Stock.find_by(code: 'JPY=X').set_prices
-    User.joins(:possessions).distinct.find_each do |user|
-      user.calculate_total_asset
-    end
+    User.joins(:possessions).distinct.find_each(&:calculate_total_asset)
   end
 end

--- a/spec/factories/total_assets.rb
+++ b/spec/factories/total_assets.rb
@@ -5,3 +5,24 @@ FactoryBot.define do
     price { 1.5 }
   end
 end
+
+# == Schema Information
+#
+# Table name: total_assets
+#
+#  id         :bigint           not null, primary key
+#  date       :date             not null
+#  price      :float            not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_total_assets_on_date     (date) UNIQUE
+#  index_total_assets_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#

--- a/spec/factories/total_assets.rb
+++ b/spec/factories/total_assets.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :total_asset do
-    user { nil }
-    date { "2023-03-29" }
-    price { 1.5 }
+    user
+    date { Time.zone.today }
+    price { 1000000 }
   end
 end
 

--- a/spec/factories/total_assets.rb
+++ b/spec/factories/total_assets.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :total_asset do
     user
     date { Time.zone.today }
-    price { 1000000 }
+    price { 1_000_000 }
   end
 end
 
@@ -19,8 +19,8 @@ end
 #
 # Indexes
 #
-#  index_total_assets_on_date     (date) UNIQUE
-#  index_total_assets_on_user_id  (user_id)
+#  index_total_assets_on_user_id           (user_id)
+#  index_total_assets_on_user_id_and_date  (user_id,date) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/factories/total_assets.rb
+++ b/spec/factories/total_assets.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :total_asset do
+    user { nil }
+    date { "2023-03-29" }
+    price { 1.5 }
+  end
+end

--- a/spec/models/total_asset_spec.rb
+++ b/spec/models/total_asset_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TotalAsset, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/total_asset_spec.rb
+++ b/spec/models/total_asset_spec.rb
@@ -29,15 +29,15 @@ end
 #
 #  id         :bigint           not null, primary key
 #  date       :date             not null
-#  total_asset      :float            not null
+#  price      :float            not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  user_id    :bigint           not null
 #
 # Indexes
 #
-#  index_total_assets_on_date     (date) UNIQUE
-#  index_total_assets_on_user_id  (user_id)
+#  index_total_assets_on_user_id           (user_id)
+#  index_total_assets_on_user_id_and_date  (user_id,date) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/models/total_asset_spec.rb
+++ b/spec/models/total_asset_spec.rb
@@ -1,7 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe TotalAsset, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    it '日付は必須であること' do
+      total_asset = build(:total_asset, date: nil)
+      total_asset.valid?
+      expect(total_asset.errors[:date]).to include('を入力してください')
+    end
+
+    it '日付は一意であること' do
+      total_asset_a = create(:total_asset, date: Time.zone.today)
+      total_asset_b = build(:total_asset, user_id: total_asset_a.user_id, date: Time.zone.today)
+      total_asset_b.valid?
+      expect(total_asset_b.errors[:date]).to include('はすでに存在します')
+    end
+
+    it '総資産額は必須であること' do
+      total_asset = build(:total_asset, price: nil)
+      total_asset.valid?
+      expect(total_asset.errors[:price]).to include('を入力してください')
+    end
+  end
 end
 
 # == Schema Information
@@ -10,7 +29,7 @@ end
 #
 #  id         :bigint           not null, primary key
 #  date       :date             not null
-#  price      :float            not null
+#  total_asset      :float            not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  user_id    :bigint           not null

--- a/spec/models/total_asset_spec.rb
+++ b/spec/models/total_asset_spec.rb
@@ -3,3 +3,24 @@ require 'rails_helper'
 RSpec.describe TotalAsset, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end
+
+# == Schema Information
+#
+# Table name: total_assets
+#
+#  id         :bigint           not null, primary key
+#  date       :date             not null
+#  price      :float            not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_total_assets_on_date     (date) UNIQUE
+#  index_total_assets_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#


### PR DESCRIPTION
# Issue
#31 
# 概要
1日に一回、ユーザーの総資産額を計算してDBに記録する。
計算は22時に行うように想定。

計算処理を作成する際に考慮したのは以下の通り
- 保有銘柄を登録しているユーザーのみ計算対象とする
- 米国株の価格はその日の日本円の価格に換算する

計算した総資産額は、保有銘柄一覧のページとダッシュボード（今後作成予定）に表示するようにする。

# その他
- N+1問題が発生していた部分を修正（今回の処理と関係ない部分も含む）
- 銘柄の価格を取得する処理を修正（正しく最新のデータが読めるようになったはず）