### PR TITLE
ダッシュボード画面の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,4 @@ gem 'rails-i18n'
 gem 'basic_yahoo_finance'
 gem 'bootstrap_form'
 gem 'whenever', require: false
+gem 'chartkick'

--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,4 @@ gem 'basic_yahoo_finance'
 gem 'bootstrap_form'
 gem 'whenever', require: false
 gem 'chartkick'
+gem 'groupdate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     faraday-net_http (3.0.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    groupdate (6.2.0)
+      activesupport (>= 5.2)
     hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -335,6 +337,7 @@ DEPENDENCIES
   debug
   erb_lint
   factory_bot_rails
+  groupdate
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chartkick (5.0.1)
     chronic (0.10.2)
     concurrent-ruby (1.2.0)
     crass (1.0.6)
@@ -329,6 +330,7 @@ DEPENDENCIES
   bootsnap
   bootstrap_form
   capybara
+  chartkick
   cssbundling-rails
   debug
   erb_lint

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
 
   private
-  
+
   def not_authenticated
     redirect_to login_url, danger: 'ログインしてください。'
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
+
+  private
+  
+  def not_authenticated
+    redirect_to login_url, danger: 'ログインしてください。'
+  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,0 +1,4 @@
+class DashboardController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,5 +2,9 @@ class DashboardController < ApplicationController
   before_action :require_login
 
   def index
+    @total_assets = current_user.total_assets.group_by_day(:created_at, last: 7).sum(:price)
+    @possessions = current_user.possessions.includes(stock: :prices).map do |possession|
+      [possession.stock.name, possession.total_price_to_jpy]
+    end
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,6 @@
 class DashboardController < ApplicationController
+  before_action :require_login
+
   def index
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_back_or_to possessions_url, success: 'ログインしました。'
+      redirect_back_or_to dashboard_url, success: 'ログインしました。'
     else
       flash.now[:danger] = 'ログインに失敗しました。'
       render :new, status: :unprocessable_entity
@@ -22,6 +22,6 @@ class SessionsController < ApplicationController
   private
 
   def redirect_to_logged_in_root
-    redirect_to possessions_path if logged_in?
+    redirect_to dashboard_url if logged_in?
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
 
     if @user.save
       auto_login(@user)
-      redirect_to possessions_url, success: 'ユーザー登録が完了しました。'
+      redirect_to dashboard_url, success: 'ユーザー登録が完了しました。'
     else
       flash.now[:danger] = 'ユーザー登録に失敗しました。'
       render :new, status: :unprocessable_entity

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import * as bootstrap from "bootstrap"
+import "chartkick/chart.js"

--- a/app/models/possession.rb
+++ b/app/models/possession.rb
@@ -28,7 +28,7 @@ class Possession < ApplicationRecord
 
   def total_price_to_jpy
     return total_price if self.stock.japanese?
-    
+
     jpy = Stock.find_by(code: 'JPY=X')
     jpy.set_prices if jpy.prices.where(date: Time.zone.today).blank?
 

--- a/app/models/possession.rb
+++ b/app/models/possession.rb
@@ -27,6 +27,8 @@ class Possession < ApplicationRecord
   end
 
   def total_price_to_jpy
+    return total_price if self.stock.japanese?
+    
     jpy = Stock.find_by(code: 'JPY=X')
     jpy.set_prices if jpy.prices.where(date: Time.zone.today).blank?
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Dashboard#index</h1>
+<p>Find me in app/views/dashboard/index.html.erb</p>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -23,7 +23,7 @@
       <div class="card-body">
         <div class="h6 text-center">
           資産総額:
-          <%= number_to_currency(@possessions.map{ |n| n[1] }.sum) %>
+          <%= number_to_currency(@possessions.sum { |n| n[1] }) %>
         </div>
       </div>
     </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,2 +1,31 @@
-<h1>Dashboard#index</h1>
-<p>Find me in app/views/dashboard/index.html.erb</p>
+<h1 class="text-center">ダッシュボード</h1>
+
+<div class="row">
+  <div class="col">
+    <div class="card m-5 shadow-sm">
+      <div class="card-body">
+        <div class="h4 text-center">資産総額の推移</div>
+      </div>
+      <div class="card-body p-5">
+        <%= column_chart @total_assets, xtitle: '日付', ytitle: '金額', suffix: '円', thousands: ',', round: 0 %>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="card m-5 shadow-sm">
+      <div class="card-body">
+        <div class="h4 text-center">保有銘柄の内訳</div>
+      </div>
+      <div class="card-body px-5">
+        <%= pie_chart @possessions, suffix: '円', thousands: ',', round: 0 %>
+      </div>
+      <div class="card-body">
+        <div class="h6 text-center">
+          資産総額:
+          <%= number_to_currency(@possessions.map{ |n| n[1] }.sum) %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -26,6 +26,9 @@
           <%= number_to_currency(@possessions.sum { |n| n[1] }) %>
         </div>
       </div>
+      <div class="card-body text-end">
+        <%= link_to '一覧へ', possessions_path, class: 'btn btn-primary' %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,8 +1,15 @@
 <header class="app-title navbar navbar-expand-md navbar-dark bg-dark">
   <div class="container-fluid">
-    <div class="navbar-brand">Invest APP</div>
+    <div class="navbar-brand">
+      <% if logged_in? %>
+        <%= link_to 'Invest APP', dashboard_path, class: 'text-light text-decoration-none' %>
+      <% else %>
+        <%= link_to 'Invest APP', root_path, class: 'text-light text-decoration-none' %>
+      <% end %>
+    </div>
     <ul class="navbar-nav ml-auto">
       <% if logged_in? %>
+        <li><%= link_to 'ダッシュボード', dashboard_path, class: 'nav-link' %></li>
         <li><%= link_to '保有銘柄', possessions_path, class: 'nav-link' %></li>
         <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: 'nav-link' %></li>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'dashboard/index'
   root to: 'static_pages#home'
 
   get 'login', to: 'sessions#new'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,11 @@
 Rails.application.routes.draw do
-  get 'dashboard/index'
   root to: 'static_pages#home'
 
   get 'login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'
+
+  get 'dashboard', to: 'dashboard#index'
 
   resources :users, except: %i(index show edit)
   resources :possessions, except: %i(show)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@popperjs/core": "^2.11.6",
     "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.10.3",
+    "chart.js": "^4.2.1",
+    "chartkick": "^5.0.1",
     "esbuild": "^0.17.5",
     "sass": "^1.58.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,6 +130,11 @@
   resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.2.5.tgz#2d9d6bde8a9549c3aea8970445ade16ffd56719a"
   integrity sha512-o5PByC/mWkmTe4pWnKrixhPECJUxIT/NHtxKqjq7n9Fj6JlNza1pgxdTCJVIq+PI0j95U+7mA3N4n4A/QYZtZQ==
 
+"@kurkle/color@^0.3.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.2.tgz#5acd38242e8bde4f9986e7913c8fdf49d3aa199f"
+  integrity sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==
+
 "@popperjs/core@^2.11.6":
   version "2.11.6"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
@@ -170,6 +175,27 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+chart.js@4, chart.js@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.2.1.tgz#d2bd5c98e9a0ae35408975b638f40513b067ba1d"
+  integrity sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
+
+chartjs-adapter-date-fns@>=3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz#c25f63c7f317c1f96f9a7c44bd45eeedb8a478e5"
+  integrity sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==
+
+chartkick@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-5.0.1.tgz#f557ff8560f974343dc65c7fc34ce1e8326d8ee7"
+  integrity sha512-4F3tWI3eBQgnjCYZIZ+fHOaJuNyxeyhDE2Tm+voOWB19hDjSJceys/spzN52DOn8bWepNESGXvPVTGU1jeFsbA==
+  optionalDependencies:
+    chart.js "4"
+    chartjs-adapter-date-fns ">=3"
+    date-fns ">=2"
+
 "chokidar@>=3.0.0 <4.0.0":
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
@@ -184,6 +210,11 @@ braces@~3.0.2:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+date-fns@>=2:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 esbuild@^0.17.5:
   version "0.17.5"


### PR DESCRIPTION
# Issue
#11 
# 概要
ダッシュボード画面を作成した。
`/dashboard`でアクセス可能。
自分の総資産額の推移（７日間）や保有銘柄の内訳が円グラフで確認できる。
# 今後やりたいこと
総資産額の推移は月単位や年単位でも見れるようにできたらいいなと思っている。
また、他に表示した方がいい項目があれば追加したい。