### PR TITLE
銘柄研究ページの実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,3 +62,7 @@ Style/RedundantSelf:
 # 使用しているAPIの使用的に厳しい気がするので少し緩める
 Metrics/AbcSize:
   Max: 25
+
+Rails/OutputSafety:
+  Exclude:
+    - 'app/helpers/markdown_helper.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -91,3 +91,4 @@ gem 'whenever', require: false
 gem 'chartkick'
 gem 'groupdate'
 gem 'httpclient'
+gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redcarpet (3.6.0)
     redis (4.8.0)
     regexp_parser (2.7.0)
     reline (0.3.2)
@@ -346,6 +347,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.2)
   rails-i18n
+  redcarpet
   redis (~> 4.0)
   rspec-rails
   rubocop

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -15,3 +15,10 @@
   display: inline-block;
   list-style: none;
 }
+
+.note_tags {
+  display: flex;
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -22,3 +22,44 @@
   padding: 0;
   margin: 0;
 }
+
+.flextextarea {
+  position: relative;
+  font-size: 1rem;
+  line-height: 1.8;
+}
+
+.flextextarea_dummy {
+  overflow: hidden;
+  visibility: hidden;
+  box-sizing: border-box;
+  padding: 5px 15px;
+  min-height: 200px;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  border: 1px solid;
+}
+
+.flextextarea_textarea {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  overflow: hidden;
+  box-sizing: border-box;
+  padding: 5px 15px;
+  width: 100%;
+  height: 100%;
+  border: 1px solid #b6c3c6;
+  border-radius: 4px;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  resize: none;
+}
+
+.flextextarea_textarea:focus {
+  box-shadow: 0 0 0 4px rgba(35, 167, 195, 0.3);
+  outline: 0;
+}

--- a/app/controllers/note_blocks_controller.rb
+++ b/app/controllers/note_blocks_controller.rb
@@ -1,7 +1,19 @@
 class NoteBlocksController < ApplicationController
+  def edit
+    @note = current_user.notes.find(params[:id])
+    @note_block = @note.note_blocks.find(params[:note_id])
+  end
+
   def create
     @note = current_user.notes.find(params[:note_id])
     @note_block = @note.note_blocks.create(note_block_params)
+    redirect_to note_url(@note, anchor: @note_block.index)
+  end
+
+  def update
+    @note = current_user.notes.find(params[:note_id])
+    @note_block = @note.note_blocks.find(params[:id])
+    @note_block.update!(note_block_params)
     redirect_to note_url(@note, anchor: @note_block.index)
   end
 

--- a/app/controllers/note_blocks_controller.rb
+++ b/app/controllers/note_blocks_controller.rb
@@ -1,2 +1,11 @@
 class NoteBlocksController < ApplicationController
+  def create
+    @note = current_user.notes.find(params[:note_id])
+    @note_block = @note.note_blocks.create(note_block_params)
+    redirect_to @note
+  end
+
+  def note_block_params
+    params.require(:note_block).permit(:content, :index)
+  end
 end

--- a/app/controllers/note_blocks_controller.rb
+++ b/app/controllers/note_blocks_controller.rb
@@ -1,0 +1,2 @@
+class NoteBlocksController < ApplicationController
+end

--- a/app/controllers/note_blocks_controller.rb
+++ b/app/controllers/note_blocks_controller.rb
@@ -2,7 +2,7 @@ class NoteBlocksController < ApplicationController
   def create
     @note = current_user.notes.find(params[:note_id])
     @note_block = @note.note_blocks.create(note_block_params)
-    redirect_to @note
+    redirect_to note_url(@note, anchor: @note_block.index)
   end
 
   def destroy

--- a/app/controllers/note_blocks_controller.rb
+++ b/app/controllers/note_blocks_controller.rb
@@ -5,6 +5,12 @@ class NoteBlocksController < ApplicationController
     redirect_to @note
   end
 
+  def destroy
+    @note = current_user.notes.find(params[:note_id])
+    @note.note_blocks.find(params[:id]).destroy!
+    redirect_to @note, status: :see_other
+  end
+
   def note_block_params
     params.require(:note_block).permit(:content, :index)
   end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,0 +1,10 @@
+class NotesController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -14,27 +14,27 @@ class NotesController < ApplicationController
   def edit
     @note = current_user.notes.find(params[:id])
   end
-  
+
   def create
     @note = current_user.notes.build(note_params)
-    
+
     if @note.save
       redirect_to note_url(@note), success: "ノート「#{@note.title}」を作成しました。"
     else
       render :new, status: :unprocessable_entity
     end
   end
-  
+
   def update
     @note = current_user.notes.find(params[:id])
-    
+
     if @note.update(note_params)
       flash.now[:success] = "ノート「#{@note.title}」を更新しました。"
     else
       render :edit, status: :unprocessable_entity
     end
   end
-  
+
   def destroy
     @note = current_user.notes.find(params[:id])
 

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,10 +1,39 @@
 class NotesController < ApplicationController
   def index
+    @notes = current_user.notes
+  end
+
+  def show
+    @note = current_user.notes.find(params[:id])
   end
 
   def new
+    @note = current_user.notes.build
   end
 
   def edit
+    @note = current_user.notes.find(params[:id])
+
+    if @note.update(note_params)
+      redirect_to note_url(@note), success: "ノート「#{@note.title}」を更新しました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def create
+    @note = current_user.notes.build(note_params)
+
+    if @note.save
+      redirect_to note_url(@note), success: "ノート「#{@note.title}」を作成しました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def note_params
+    params.require(:note).permit(:title)
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -13,22 +13,33 @@ class NotesController < ApplicationController
 
   def edit
     @note = current_user.notes.find(params[:id])
-
-    if @note.update(note_params)
-      redirect_to note_url(@note), success: "ノート「#{@note.title}」を更新しました。"
-    else
-      render :new, status: :unprocessable_entity
-    end
   end
-
+  
   def create
     @note = current_user.notes.build(note_params)
-
+    
     if @note.save
       redirect_to note_url(@note), success: "ノート「#{@note.title}」を作成しました。"
     else
       render :new, status: :unprocessable_entity
     end
+  end
+  
+  def update
+    @note = current_user.notes.find(params[:id])
+    
+    if @note.update(note_params)
+      flash.now[:success] = "ノート「#{@note.title}」を更新しました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+  
+  def destroy
+    @note = current_user.notes.find(params[:id])
+
+    @note.destroy!
+    redirect_to notes_url, success: "ノート「#{@note.title}」を削除しました。", status: :see_other
   end
 
   private

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,21 @@
+module MarkdownHelper
+  def markdown(text)
+    options = {
+      filter_html: true,
+      hard_wrap: true
+    }
+
+    extensions = {
+      no_intraemphasis: true,
+      tables: true,
+      fenced_code_blocks: true,
+      autolink: true,
+      strikethrough: true,
+      space_after_headers: true
+    }
+
+    renderer = Redcarpet::Render::HTML.new(options)
+    markdown = Redcarpet::Markdown.new(renderer, extensions)
+    markdown.render(text).html_safe
+  end
+end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -3,7 +3,7 @@ import { Application } from "@hotwired/stimulus"
 const application = Application.start()
 
 // Configure Stimulus development experience
-application.debug = false
+application.debug = true
 window.Stimulus   = application
 
 export { application }

--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="form"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -2,6 +2,9 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="form"
 export default class extends Controller {
-  connect() {
+  static targets = ["input", "output"];
+
+  resize() {
+    this.outputTarget.textContent = this.inputTarget.value + '\u200b';
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import FormController from "./form_controller"
+application.register("form", FormController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,3 @@
+class Note < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,7 +1,7 @@
 class Note < ApplicationRecord
   belongs_to :user
 
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 50 }
   validates :private, presence: true
 end
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,6 @@
 class Note < ApplicationRecord
   belongs_to :user
+  has_many :note_blocks, dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :private, presence: true

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,8 @@
 class Note < ApplicationRecord
   belongs_to :user
+
+  validates :title, presence: true
+  validates :private, presence: true
 end
 
 # == Schema Information

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,3 +1,23 @@
 class Note < ApplicationRecord
   belongs_to :user
 end
+
+# == Schema Information
+#
+# Table name: notes
+#
+#  id         :bigint           not null, primary key
+#  private    :boolean          default(TRUE), not null
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_notes_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/note_block.rb
+++ b/app/models/note_block.rb
@@ -1,5 +1,7 @@
 class NoteBlock < ApplicationRecord
   belongs_to :note
+
+  validates :index, presence: true
 end
 
 # == Schema Information

--- a/app/models/note_block.rb
+++ b/app/models/note_block.rb
@@ -1,3 +1,23 @@
 class NoteBlock < ApplicationRecord
   belongs_to :note
 end
+
+# == Schema Information
+#
+# Table name: note_blocks
+#
+#  id         :bigint           not null, primary key
+#  content    :text
+#  index      :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  note_id    :bigint           not null
+#
+# Indexes
+#
+#  index_note_blocks_on_note_id  (note_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (note_id => notes.id)
+#

--- a/app/models/note_block.rb
+++ b/app/models/note_block.rb
@@ -1,0 +1,3 @@
+class NoteBlock < ApplicationRecord
+  belongs_to :note
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_many :possessions, dependent: :destroy
   has_many :stocks, through: :possessions
   has_many :total_assets, dependent: :destroy
+  has_many :notes, dependent: :destroy
 
   authenticates_with_sorcery!
 

--- a/app/views/note_blocks/_form.html.erb
+++ b/app/views/note_blocks/_form.html.erb
@@ -1,5 +1,8 @@
-<%= form_with model: [@note, @note.note_blocks.build] do |f| %>
-  <%= f.text_area :content, class: 'form-control' %>
+<%= form_with model: [@note, @note.note_blocks.build], data: { turbo: false } do |f| %>
+  <div class="flextextarea" data-controller="form">
+    <div class="flextextarea_dummy" area-hidden="true" data-form-target="output"></div>
+    <%= f.text_area :content, class: 'flextextarea_textarea', id: 'flextextarea', data: { action: 'form#resize', 'form-target': 'input' } %>
+  </div>
   <%= f.hidden_field :index, value: @note.note_blocks.size %>
   <%= f.submit class: 'btn btn-primary my-3' %>
 <% end %>

--- a/app/views/note_blocks/_form.html.erb
+++ b/app/views/note_blocks/_form.html.erb
@@ -1,0 +1,5 @@
+<%= form_with model: [@note, @note.note_blocks.build] do |f| %>
+  <%= f.text_area :content, class: 'form-control' %>
+  <%= f.hidden_field :index, value: @note.note_blocks.size %>
+  <%= f.submit class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/note_blocks/_form.html.erb
+++ b/app/views/note_blocks/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: [@note, @note.note_blocks.build] do |f| %>
   <%= f.text_area :content, class: 'form-control' %>
   <%= f.hidden_field :index, value: @note.note_blocks.size %>
-  <%= f.submit class: 'btn btn-primary' %>
+  <%= f.submit class: 'btn btn-primary my-3' %>
 <% end %>

--- a/app/views/note_blocks/_note_block.html.erb
+++ b/app/views/note_blocks/_note_block.html.erb
@@ -1,0 +1,6 @@
+<div class="row">
+  <div class="col">
+    <%= note_block.content %>
+    <%= note_block.index %>
+  </div>
+</div>

--- a/app/views/note_blocks/_note_block.html.erb
+++ b/app/views/note_blocks/_note_block.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag note_block do %>
   <div class="block mt-3 mb-5 d-flex align-items-center">
-    <div class="d-block">
+    <div class="d-block" id="<%= note_block.index %>">
       <%= markdown(note_block.content) %>
     </div>
     <div class="ms-auto">

--- a/app/views/note_blocks/_note_block.html.erb
+++ b/app/views/note_blocks/_note_block.html.erb
@@ -4,6 +4,7 @@
       <%= markdown(note_block.content) %>
     </div>
     <div class="ms-auto">
+      <%= link_to '編集', edit_note_note_block_path(note_block), class: 'btn btn-primary' %>
       <%= link_to '削除', note_note_block_path(@note, note_block), data: { turbo_method: :delete }, class: 'btn btn-danger' %>
     </div>
   </div>

--- a/app/views/note_blocks/_note_block.html.erb
+++ b/app/views/note_blocks/_note_block.html.erb
@@ -1,6 +1,8 @@
-<div class="row">
-  <div class="col">
+<%= turbo_frame_tag note_block do %>
+  <div class="block mt-3 mb-5 d-flex align-items-center">
     <%= note_block.content %>
-    <%= note_block.index %>
+    <div class="ms-auto">
+      <%= link_to '削除', note_note_block_path(@note, note_block), data: { turbo_method: :delete }, class: 'btn btn-danger' %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/note_blocks/_note_block.html.erb
+++ b/app/views/note_blocks/_note_block.html.erb
@@ -1,6 +1,8 @@
 <%= turbo_frame_tag note_block do %>
   <div class="block mt-3 mb-5 d-flex align-items-center">
-    <%= note_block.content %>
+    <div class="d-block">
+      <%= markdown(note_block.content) %>
+    </div>
     <div class="ms-auto">
       <%= link_to '削除', note_note_block_path(@note, note_block), data: { turbo_method: :delete }, class: 'btn btn-danger' %>
     </div>

--- a/app/views/note_blocks/edit.html.erb
+++ b/app/views/note_blocks/edit.html.erb
@@ -1,0 +1,11 @@
+<%= turbo_frame_tag @note_block do %>
+  <%= form_with model: [@note, @note_block] do |f| %>
+    <div class="flextextarea" data-controller="form">
+      <div class="flextextarea_dummy" area-hidden="true" data-form-target="output"></div>
+      <%= f.text_area :content, class: 'flextextarea_textarea', id: 'flextextarea', data: { action: 'form#resize', 'form-target': 'input' } %>
+    </div>
+    <%= f.hidden_field :index, value: @note_block.index %>
+    <%= f.submit class: 'btn btn-primary my-3' %>
+  <% end %>
+  <%= link_to 'キャンセル', note_path(@note), class: 'btn btn-outline-secondary' %>
+<% end %>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -1,0 +1,15 @@
+<div class="row card-body border-bottom">
+  <div class="col text-3">
+    <%= link_to note.title, note_path(note) %>
+  </div>
+  <div class="col">
+    <ul class="note_tags">
+      <li class="me-1">タグ１</li>
+      <li class="me-1">タグ２</li>
+      <li class="me-1">タグ３</li>
+    </ul>
+  </div>
+  <div class="col">
+    作成日:<%= note.created_at %>
+  </div>
+</div>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -10,6 +10,6 @@
     </ul>
   </div>
   <div class="col">
-    作成日:<%= note.created_at %>
+    作成日時:<%= note.created_at.strftime('%Y/%m/%d %H:%M:%S') %>
   </div>
 </div>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Notes#edit</h1>
+<p>Find me in app/views/notes/edit.html.erb</p>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,2 +1,9 @@
-<h1>Notes#edit</h1>
-<p>Find me in app/views/notes/edit.html.erb</p>
+<%= turbo_frame_tag @note do %>
+  <hr>
+  <%= bootstrap_form_with model: @note do |f| %>
+    <%= f.text_field :title, maxlength: 50, help: 'タイトルは50文字まで入力できます。', placeholder: 'ここにタイトルを入力' %>
+    <%= f.submit class: 'btn btn-sm btn-primary me-3' %>
+    <%= link_to 'キャンセル', @note, class: 'btn btn-sm btn-outline-secondary' %>
+  <% end %>
+  <hr>
+<% end %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Notes#index</h1>
+<p>Find me in app/views/notes/index.html.erb</p>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,2 +1,13 @@
-<h1>Notes#index</h1>
-<p>Find me in app/views/notes/index.html.erb</p>
+<div class="col-md-8">
+  <h1 class="text-center mb-5">研究ノート</h1>
+  <%= link_to '＋ノートを作成', new_note_path, class: 'btn btn-primary mb-3' %>
+  <div class="card shadow-sm">
+    <% if @notes.blank? %>
+      <div class="card-body text-center">
+        まだノートがありません。ノートを作成ボタンから作成してみましょう！
+      </div>
+    <% else %>
+      <%= render @notes %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Notes#new</h1>
+<p>Find me in app/views/notes/new.html.erb</p>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,2 +1,16 @@
-<h1>Notes#new</h1>
-<p>Find me in app/views/notes/new.html.erb</p>
+<div class="col-md-8">
+  <h1 class="text-center mb-5">ノートを新規作成</h1>
+
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <div class="text-secondary mb-5">
+        ノートを新規作成した後に、内容を追記していくことができます。<br>
+        まずはタイトルをつけてノートを作成してみましょう。
+      </div>
+      <%= bootstrap_form_with model: @note do |f| %>
+        <%= f.text_field :title, maxlength: 50, help: 'タイトルは50文字まで入力できます。', placeholder: 'ここにタイトルを入力' %>
+        <%= f.submit '作成する', class: 'btn btn-primary' %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -18,5 +18,6 @@
 
   <hr>
 
-  個別のメモ欄ここから
+  <%= render @note.note_blocks %>
+  <%= render 'note_blocks/form' %>
 </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -18,6 +18,10 @@
 
   <hr>
 
-  <%= render @note.note_blocks %>
-  <%= render 'note_blocks/form' %>
+  <div class="row">
+    <div class="col">
+      <%= render @note.note_blocks %>
+      <%= render 'note_blocks/form' %>
+    </div>
+  </div>
 </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -20,7 +20,7 @@
 
   <div class="row">
     <div class="col">
-      <%= render @note.note_blocks %>
+      <%= render @note.note_blocks.order(index: :asc) %>
       <%= render 'note_blocks/form' %>
     </div>
   </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,27 +1,29 @@
 <div class="col-md-8">
   <%= link_to '一覧', notes_path, class: 'nav-link' %>
-  <div class="d-flex justify-content-end">
-    <%= link_to '編集', edit_note_path, data: { turbo_frame: dom_id(@note) }, class: 'btn btn-primary me-3' %>
-    <%= link_to '削除', @note, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-danger' %>
-  </div>
-  <div class="my-3">
-    <%= image_tag 'https://placehold.jp/150x150.png', alt: 'プロフィール画像', class: 'rounded-circle', width: '50' %>
-    <%= @note.user.username %>
-  </div>
-  <%= turbo_frame_tag @note do %>
-    <div class="h2">
-      <%= @note.title %>
-      <%= '(非公開)' if @note.private %>
+  <div class="card card-body">
+    <div class="d-flex justify-content-end">
+      <%= link_to '編集', edit_note_path, data: { turbo_frame: dom_id(@note) }, class: 'btn btn-primary me-3' %>
+      <%= link_to '削除', @note, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-danger' %>
     </div>
-  <% end %>
-  <%= @note.created_at.strftime('%Y/%m/%d %H:%M:%S') %>
+    <div class="my-3">
+      <%= image_tag 'https://placehold.jp/150x150.png', alt: 'プロフィール画像', class: 'rounded-circle', width: '50' %>
+      <%= @note.user.username %>
+    </div>
+    <%= turbo_frame_tag @note do %>
+      <div class="h2">
+        <%= @note.title %>
+        <%= '(非公開)' if @note.private %>
+      </div>
+    <% end %>
+    <%= @note.created_at.strftime('%Y/%m/%d %H:%M:%S') %>
 
-  <hr>
+    <hr>
 
-  <div class="row">
-    <div class="col">
-      <%= render @note.note_blocks.order(index: :asc) %>
-      <%= render 'note_blocks/form' %>
+    <div class="row">
+      <div class="col">
+        <%= render @note.note_blocks.order(index: :asc) %>
+        <%= render 'note_blocks/form' %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,0 +1,14 @@
+<div class="col-md-8">
+  <div class="d-flex justify-content-end">
+    <%= link_to '一覧へ', notes_path, class: 'nav-link' %>
+  </div>
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h1><%= @note.title %></h1>
+      <div class="user_area">
+        <%= @note.user.username %>
+      </div>
+      <%= @note.created_at.strftime('%Y/%m/%d %H:%M:%S') %>
+    </div>
+  </div>
+</div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,14 +1,22 @@
 <div class="col-md-8">
+  <%= link_to '一覧', notes_path, class: 'nav-link' %>
   <div class="d-flex justify-content-end">
-    <%= link_to '一覧へ', notes_path, class: 'nav-link' %>
+    <%= link_to '編集', edit_note_path, data: { turbo_frame: dom_id(@note) }, class: 'btn btn-primary me-3' %>
+    <%= link_to '削除', @note, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-danger' %>
   </div>
-  <div class="card shadow-sm">
-    <div class="card-body">
-      <h1><%= @note.title %></h1>
-      <div class="user_area">
-        <%= @note.user.username %>
-      </div>
-      <%= @note.created_at.strftime('%Y/%m/%d %H:%M:%S') %>
+  <div class="my-3">
+    <%= image_tag 'https://placehold.jp/150x150.png', alt: 'プロフィール画像', class: 'rounded-circle', width: '50' %>
+    <%= @note.user.username %>
+  </div>
+  <%= turbo_frame_tag @note do %>
+    <div class="h2">
+      <%= @note.title %>
+      <%= '(非公開)' if @note.private %>
     </div>
-  </div>
+  <% end %>
+  <%= @note.created_at.strftime('%Y/%m/%d %H:%M:%S') %>
+
+  <hr>
+
+  個別のメモ欄ここから
 </div>

--- a/app/views/notes/update.turbo_stream.erb
+++ b/app/views/notes/update.turbo_stream.erb
@@ -1,0 +1,10 @@
+<%= turbo_stream.update dom_id(@note) do %>
+  <div class="h2">
+    <%= @note.title %>
+    <%= '(非公開)' if @note.private %>
+  </div>
+<% end %>
+
+<%= turbo_stream.update 'flash' do %>
+  <%= render 'shared/flash_messages' %>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,9 +7,10 @@
         <%= link_to 'Invest APP', root_path, class: 'text-light text-decoration-none' %>
       <% end %>
     </div>
-    <ul class="navbar-nav ml-auto">
+    <ul class="navbar-nav">
       <% if logged_in? %>
         <li><%= link_to 'ダッシュボード', dashboard_path, class: 'nav-link' %></li>
+        <li><%= link_to '研究ノート', notes_path, class: 'nav-link' %></li>
         <li><%= link_to '保有銘柄', possessions_path, class: 'nav-link' %></li>
         <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: 'nav-link' %></li>
       <% else %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       user: ユーザー
       possession: 保有銘柄
+      note: 研究ノート
     attributes:
       user:
         id: ID
@@ -23,3 +24,6 @@ ja:
         market_close: 現在価格
       stock:
         category: 分類
+      note:
+        title: タイトル
+        private: プライベート

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'notes/index'
+  get 'notes/new'
+  get 'notes/edit'
   root to: 'static_pages#home'
 
   get 'login', to: 'sessions#new'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,4 @@
 Rails.application.routes.draw do
-  get 'notes/index'
-  get 'notes/new'
-  get 'notes/edit'
   root to: 'static_pages#home'
 
   get 'login', to: 'sessions#new'
@@ -12,4 +9,5 @@ Rails.application.routes.draw do
 
   resources :users, except: %i(index show edit)
   resources :possessions, except: %i(show)
+  resources :notes
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,7 @@ Rails.application.routes.draw do
 
   resources :users, except: %i(index show edit)
   resources :possessions, except: %i(show)
-  resources :notes
+  resources :notes do
+    resources :note_blocks, except: %i(index show)
+  end
 end

--- a/db/migrate/20230418145724_create_notes.rb
+++ b/db/migrate/20230418145724_create_notes.rb
@@ -1,0 +1,11 @@
+class CreateNotes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :notes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title
+      t.boolean :private
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230418145724_create_notes.rb
+++ b/db/migrate/20230418145724_create_notes.rb
@@ -2,8 +2,8 @@ class CreateNotes < ActiveRecord::Migration[7.0]
   def change
     create_table :notes do |t|
       t.references :user, null: false, foreign_key: true
-      t.string :title
-      t.boolean :private
+      t.string :title, null: false
+      t.boolean :private, null: false, default: true
 
       t.timestamps
     end

--- a/db/migrate/20230424143559_create_note_blocks.rb
+++ b/db/migrate/20230424143559_create_note_blocks.rb
@@ -3,7 +3,7 @@ class CreateNoteBlocks < ActiveRecord::Migration[7.0]
     create_table :note_blocks do |t|
       t.references :note, null: false, foreign_key: true
       t.text :content
-      t.integer :index
+      t.integer :index, null: false
 
       t.timestamps
     end

--- a/db/migrate/20230424143559_create_note_blocks.rb
+++ b/db/migrate/20230424143559_create_note_blocks.rb
@@ -1,0 +1,11 @@
+class CreateNoteBlocks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :note_blocks do |t|
+      t.references :note, null: false, foreign_key: true
+      t.text :content
+      t.integer :index
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_18_145724) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_24_143559) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "note_blocks", force: :cascade do |t|
+    t.bigint "note_id", null: false
+    t.text "content"
+    t.integer "index", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["note_id"], name: "index_note_blocks_on_note_id"
+  end
 
   create_table "notes", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -81,6 +90,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_18_145724) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "note_blocks", "notes"
   add_foreign_key "notes", "users"
   add_foreign_key "possessions", "stocks"
   add_foreign_key "possessions", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_29_032421) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_18_145724) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "notes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.boolean "private", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_notes_on_user_id"
+  end
 
   create_table "possessions", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -72,6 +81,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_032421) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "notes", "users"
   add_foreign_key "possessions", "stocks"
   add_foreign_key "possessions", "users"
   add_foreign_key "prices", "stocks"

--- a/spec/factories/note_blocks.rb
+++ b/spec/factories/note_blocks.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :note_block do
     note { nil }
-    content { "MyText" }
+    content { 'MyText' }
     index { 1 }
   end
 end

--- a/spec/factories/note_blocks.rb
+++ b/spec/factories/note_blocks.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :note_block do
+    note { nil }
+    content { "MyText" }
+    index { 1 }
+  end
+end

--- a/spec/factories/note_blocks.rb
+++ b/spec/factories/note_blocks.rb
@@ -5,3 +5,23 @@ FactoryBot.define do
     index { 1 }
   end
 end
+
+# == Schema Information
+#
+# Table name: note_blocks
+#
+#  id         :bigint           not null, primary key
+#  content    :text
+#  index      :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  note_id    :bigint           not null
+#
+# Indexes
+#
+#  index_note_blocks_on_note_id  (note_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (note_id => notes.id)
+#

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :note do
+    user { nil }
+    title { "MyString" }
+    private { false }
+  end
+end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -5,3 +5,23 @@ FactoryBot.define do
     private { false }
   end
 end
+
+# == Schema Information
+#
+# Table name: notes
+#
+#  id         :bigint           not null, primary key
+#  private    :boolean          default(TRUE), not null
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_notes_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :note do
-    user { nil }
-    title { "MyString" }
-    private { false }
+    user
+    title { 'test' }
+    private { true }
   end
 end
 

--- a/spec/models/note_block_spec.rb
+++ b/spec/models/note_block_spec.rb
@@ -3,3 +3,23 @@ require 'rails_helper'
 RSpec.describe NoteBlock, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end
+
+# == Schema Information
+#
+# Table name: note_blocks
+#
+#  id         :bigint           not null, primary key
+#  content    :text
+#  index      :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  note_id    :bigint           not null
+#
+# Indexes
+#
+#  index_note_blocks_on_note_id  (note_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (note_id => notes.id)
+#

--- a/spec/models/note_block_spec.rb
+++ b/spec/models/note_block_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe NoteBlock, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Note, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,7 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Note, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    it 'タイトルは必須であること' do
+      note = build(:note, title: nil)
+      note.valid?
+      expect(note.errors[:title]).to include('を入力してください')
+    end
+  end
 end
 
 # == Schema Information

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -3,3 +3,23 @@ require 'rails_helper'
 RSpec.describe Note, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end
+
+# == Schema Information
+#
+# Table name: notes
+#
+#  id         :bigint           not null, primary key
+#  private    :boolean          default(TRUE), not null
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_notes_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#


### PR DESCRIPTION
# Issue
#29

# 概要
銘柄研究ページの基本的なCRUDを実装した。
機能名は研究ノートとした。
作成手順は
1. 研究ノートを新規作成。タイトルを決めて作成する。
2. 作成したノートにアクセス
3. 明細入力欄に、メモ等を入力し登録

となっている。現在基本的な機能のみのため、使いやすくするための機能は別途実装したい。

# 機能追加の案
- URLを登録すると、OGPを表示する機能
- 銘柄名を指定したキーワードを入力することで、その銘柄の情報を表示する機能
- 明細の順番を入れ替える機能
- 明細の途中に新しい明細を挿入する機能