### PR TITLE
銘柄登録時に銘柄名をインクリメンタルサーチできるように

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,5 +1,6 @@
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';
+@import "tom-select/dist/css/tom-select.bootstrap5";
 
 .bg-gray {
   background-color: #e8e8e8;

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -4,9 +4,9 @@ class StocksController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.json {
+      format.json do
         render json: @stocks.map { |s| { id: s.id, name: "#{s.code}:#{s.name}" } }
-      }
+      end
     end
   end
 end

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -1,0 +1,12 @@
+class StocksController < ApplicationController
+  def index
+    @stocks = params[:q] ? Stock.where('name LIKE ?', "%#{params[:q]}%").or(Stock.where('code LIKE ?', "%#{params[:q]}%")) : Stock.all
+
+    respond_to do |format|
+      format.html
+      format.json {
+        render json: @stocks.map { |s| { id: s.id, name: "#{s.code}:#{s.name}" } }
+      }
+    end
+  end
+end

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -1,6 +1,6 @@
 class StocksController < ApplicationController
   def index
-    @stocks = params[:q] ? Stock.where('name LIKE ?', "%#{params[:q]}%").or(Stock.where('code LIKE ?', "%#{params[:q]}%")) : Stock.all
+    @stocks = params[:q] ? Stock.where('name ILIKE ?', "%#{params[:q]}%").or(Stock.where('code ILIKE ?', "%#{params[:q]}%")) : Stock.all
 
     respond_to do |format|
       format.html

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("form", FormController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import SelectStocksController from "./select_stocks_controller"
+application.register("select-stocks", SelectStocksController)

--- a/app/javascript/controllers/select_stocks_controller.js
+++ b/app/javascript/controllers/select_stocks_controller.js
@@ -1,7 +1,12 @@
 import { Controller } from "@hotwired/stimulus"
+import TomSelect from "tom-select"
 
 // Connects to data-controller="select-stocks"
 export default class extends Controller {
+  static targets = ["selectBox"];
+
   connect() {
+    const config = {};
+    new TomSelect(this.selectBoxTarget, config);
   }
 }

--- a/app/javascript/controllers/select_stocks_controller.js
+++ b/app/javascript/controllers/select_stocks_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="select-stocks"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/select_stocks_controller.js
+++ b/app/javascript/controllers/select_stocks_controller.js
@@ -7,6 +7,11 @@ export default class extends Controller {
 
   connect() {
     const config = {
+      plugins: {
+        'clear_button': {
+          'title': '入力をリセット'
+        }
+      },
       valueField: 'id',
       labelField: 'name',
       searchField: 'name',

--- a/app/javascript/controllers/select_stocks_controller.js
+++ b/app/javascript/controllers/select_stocks_controller.js
@@ -6,7 +6,22 @@ export default class extends Controller {
   static targets = ["selectBox"];
 
   connect() {
-    const config = {};
+    const config = {
+      valueField: 'id',
+      labelField: 'name',
+      searchField: 'name',
+      selectOnTab: true,
+      load: (query, callback) => {
+        var url = this.selectBoxTarget.dataset.urlValue + '.json?q=' + encodeURIComponent(query);
+        fetch(url)
+          .then(response => response.json())
+          .then(json => {
+            callback(json);
+          }).catch(() => {
+            callback();
+          });
+      }
+    };
     new TomSelect(this.selectBoxTarget, config);
   }
 }

--- a/app/views/possessions/new.html.erb
+++ b/app/views/possessions/new.html.erb
@@ -10,7 +10,7 @@
       <div class="form-group col-2">
         <%= f.number_field :volume, min: 1 %>
       </div>
-    </div>  
+    </div>
     <div class="row pb-5 mb-3 border-bottom">
       <div class="form-group col-9">
         <%= f.text_field :memo, maxlength: 50, help: 'メモは50文字まで入力できます。' %>

--- a/app/views/possessions/new.html.erb
+++ b/app/views/possessions/new.html.erb
@@ -1,8 +1,8 @@
 <%= turbo_frame_tag 'new_possession' do %>
   <%= bootstrap_form_with model: @possession do |f| %>
-    <div class="row">
+    <div class="row" data-controller="select-stocks">
       <div class="form-group col-5">
-        <%= f.collection_select :stock_id, Stock.all, :id, ->(stock) { "#{stock.code}:#{stock.name}" }, prompt: '選択してください' %>
+        <%= f.collection_select :stock_id, Stock.all, :id, ->(stock) { "#{stock.code}:#{stock.name}" }, { include_blank: '銘柄を選択' }, data: { 'select-stocks_target': 'selectBox' } %>
       </div>
       <div class="form-group col-2">
         <%= f.number_field :price, min: 0, step: 0.1 %>

--- a/app/views/possessions/new.html.erb
+++ b/app/views/possessions/new.html.erb
@@ -1,8 +1,8 @@
 <%= turbo_frame_tag 'new_possession' do %>
   <%= bootstrap_form_with model: @possession do |f| %>
-    <div class="row" data-controller="select-stocks">
+    <div class="row" data-controller="select-stocks" data-select-stocks_url_value="/stocks">
       <div class="form-group col-5">
-        <%= f.collection_select :stock_id, Stock.all, :id, ->(stock) { "#{stock.code}:#{stock.name}" }, { include_blank: '銘柄を選択' }, data: { 'select-stocks_target': 'selectBox' } %>
+        <%= f.collection_select :stock_id, {}, :id, ->(stock) { "#{stock.code}:#{stock.name}" }, { include_blank: '銘柄を検索(証券コード or ティッカー or 銘柄名)' }, data: { 'select-stocks_target': 'selectBox', url_value: stocks_path } %>
       </div>
       <div class="form-group col-2">
         <%= f.number_field :price, min: 0, step: 0.1 %>
@@ -10,7 +10,7 @@
       <div class="form-group col-2">
         <%= f.number_field :volume, min: 1 %>
       </div>
-    </div>
+    </div>  
     <div class="row pb-5 mb-3 border-bottom">
       <div class="form-group col-9">
         <%= f.text_field :memo, maxlength: 50, help: 'メモは50文字まで入力できます。' %>

--- a/app/views/possessions/new.html.erb
+++ b/app/views/possessions/new.html.erb
@@ -1,8 +1,10 @@
 <%= turbo_frame_tag 'new_possession' do %>
   <%= bootstrap_form_with model: @possession do |f| %>
-    <div class="row" data-controller="select-stocks" data-select-stocks_url_value="/stocks">
+    <div class="row">
       <div class="form-group col-5">
-        <%= f.collection_select :stock_id, {}, :id, ->(stock) { "#{stock.code}:#{stock.name}" }, { include_blank: '銘柄を検索(証券コード or ティッカー or 銘柄名)' }, data: { 'select-stocks_target': 'selectBox', url_value: stocks_path } %>
+        <%= f.collection_select :stock_id, {}, :id, ->(stock) { "#{stock.code}:#{stock.name}" },
+                                { include_blank: '銘柄を検索(証券コード or ティッカー or 銘柄名)' },
+                                data: { controller: 'select-stocks', 'select-stocks_target': 'selectBox', url_value: stocks_path } %>
       </div>
       <div class="form-group col-2">
         <%= f.number_field :price, min: 0, step: 0.1 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,6 @@ Rails.application.routes.draw do
   namespace :mypage do
     resource :account, only: %i(show edit update)
   end
+
+  resources :stocks, only: %i(index)
 end

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "chart.js": "^4.2.1",
     "chartkick": "^5.0.1",
     "esbuild": "^0.17.5",
-    "sass": "^1.58.0"
+    "sass": "^1.58.0",
+    "tom-select": "^2.2.2"
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets",

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,6 +135,18 @@
   resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.2.tgz#5acd38242e8bde4f9986e7913c8fdf49d3aa199f"
   integrity sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==
 
+"@orchidjs/sifter@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@orchidjs/sifter/-/sifter-1.0.3.tgz#43f42519472282eb632d0a1589184f044d64129b"
+  integrity sha512-zCZbwKegHytfsPm8Amcfh7v/4vHqTAaOu6xFswBYcn8nznBOuseu6COB2ON7ez0tFV0mKL0nRNnCiZZA+lU9/g==
+  dependencies:
+    "@orchidjs/unicode-variants" "^1.0.4"
+
+"@orchidjs/unicode-variants@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@orchidjs/unicode-variants/-/unicode-variants-1.0.4.tgz#6d2f812e3b19545bba2d81caffff1204de9a6a58"
+  integrity sha512-NvVBRnZNE+dugiXERFsET1JlKZfM5lJDEpSMilKW4bToYJ7pxf0Zne78xyXB2ny2c2aHfJ6WLnz1AaTNHAmQeQ==
+
 "@popperjs/core@^2.11.6":
   version "2.11.6"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
@@ -329,3 +341,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+tom-select@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/tom-select/-/tom-select-2.2.2.tgz#8e5f9296e6d80254feccb57f0986bd6c44d126e2"
+  integrity sha512-igGah1yY6yhrnN2h/Ky8I5muw/nE/YQxIsEZoYu5qaA4bsRibvKto3s8QZZosKpOd0uO8fNYhRfAwgHB4IAYew==
+  dependencies:
+    "@orchidjs/sifter" "^1.0.3"
+    "@orchidjs/unicode-variants" "^1.0.4"


### PR DESCRIPTION
# Issue
#19
# 概要
## 改善前
登録可能な銘柄をすべて（12000レコード超！）セレクトボックスの要素として読み込んでいたため、銘柄登録画面の表示が遅かった。
ローカル環境でも1秒前後かかっていたため本番環境だともっとかかりそう。
## 改善後
登録画面表示の際の読み込みはなくし、検索ボックスに銘柄名の一部を入力すると、その都度DBから一致する銘柄を検索（インクリメンタルサーチ）するようにした。
そのため表示スピードが改善された。

インクリメンタルサーチの実装にあたってはTom-SelectというJavaScriptのライブラリを使用した。
https://tom-select.js.org/

# 今後の課題
検索する際、文字を入力するたびにサーバーに対してリクエストが発生するため、負荷が心配。
文字を入力して一定時間入力がない場合にリクエストが発生するようにできればよさそうだが、今後の課題とする。