### PR TITLE
fix gem basic_yahoo_financeの更新および取得処理への再適用

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,8 @@ GEM
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
-    basic_yahoo_finance (0.3.1)
+    basic_yahoo_finance (0.5.1)
+      net-http-persistent (~> 4.0, >= 4.0.2)
     bcrypt (3.1.18)
     better_html (2.0.1)
       actionview (>= 6.0)
@@ -100,6 +101,7 @@ GEM
     chartkick (5.0.1)
     chronic (0.10.2)
     concurrent-ruby (1.2.0)
+    connection_pool (2.4.1)
     crass (1.0.6)
     cssbundling-rails (1.1.2)
       railties (>= 6.0.0)
@@ -158,6 +160,8 @@ GEM
     minitest (5.17.0)
     msgpack (1.6.0)
     multi_xml (0.6.0)
+    net-http-persistent (4.0.2)
+      connection_pool (~> 2.2)
     net-imap (0.3.4)
       date
       net-protocol

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -9,35 +9,25 @@ class Stock < ApplicationRecord
   def set_prices
     symbol = self.code
     symbol += '.T' if self.category.zero? # 日本株の場合、証券コードの末尾に.Tをつける
-    # query = BasicYahooFinance::Query.new
-    # data = query.quotes(symbol)
-
-    uri = "https://query2.finance.yahoo.com/v10/finance/quoteSummary/#{symbol}?modules=price"
-    client = HTTPClient.new
-    request = client.get(uri)
-    response = JSON.parse(request.body)['quoteSummary']['result'][0]['price']
+    query = BasicYahooFinance::Query.new
+    data = query.quotes(symbol)
 
     prices.create(
       date: Time.zone.today,
-      market_open: response['regularMarketOpen']['raw'],
-      daily_high: response['regularMarketDayHigh']['raw'],
-      daily_low: response['regularMarketDayLow']['raw'],
-      market_close: response['regularMarketPrice']['raw']
+      market_open: data[symbol]['regularMarketOpen']['raw'],
+      daily_high: data[symbol]['regularMarketDayHigh']['raw'],
+      daily_low: data[symbol]['regularMarketDayLow']['raw'],
+      market_close: data[symbol]['regularMarketPrice']['raw']
     )
   end
 
   def update_prices
     symbol = self.code
     symbol += '.T' if self.category.zero? # 日本株の場合、証券コードの末尾に.Tをつける
-    # query = BasicYahooFinance::Query.new
-    # data = query.quotes(symbol)
+    query = BasicYahooFinance::Query.new
+    data = query.quotes(symbol)
 
-    uri = "https://query2.finance.yahoo.com/v10/finance/quoteSummary/#{symbol}?modules=price"
-    client = HTTPClient.new
-    request = client.get(uri)
-    response = JSON.parse(request.body)['quoteSummary']['result'][0]['price']
-
-    prices.last.update(market_close: response['regularMarketPrice']['raw'])
+    prices.last.update(market_close: data[symbol]['regularMarketPrice']['raw'])
   end
 
   def japanese?


### PR DESCRIPTION
# 概要
YahooFinanceの仕様変更により株価が取得できなくなっていたため修正
gem basic_yahoo_financeが更新されており株価の取得に対応していたため、再度こちらを使用するように変更