### PR TITLE
modify ヘッダーメニューのマイページ関連をアイコンからのプルダウンへ

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -2,8 +2,9 @@
 @import 'bootstrap-icons/font/bootstrap-icons';
 @import "tom-select/dist/css/tom-select.bootstrap5";
 
-.bg-gray {
-  background-color: #e8e8e8;
+.header-myicon {
+  height: calc(100% + 20px);
+  margin: -10px 10px;
 }
 
 .hero {

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,17 +7,36 @@
         <%= link_to 'Invest APP', root_path, class: 'text-light text-decoration-none' %>
       <% end %>
     </div>
-    <ul class="navbar-nav">
-      <% if logged_in? %>
-        <li><%= link_to 'ダッシュボード', dashboard_path, class: 'nav-link' %></li>
-        <li><%= link_to '研究ノート', notes_path, class: 'nav-link' %></li>
-        <li><%= link_to '保有銘柄', possessions_path, class: 'nav-link' %></li>
-        <li><%= link_to 'マイページ', mypage_account_path, class: 'nav-link' %></li>
-        <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: 'nav-link' %></li>
-      <% else %>
-        <li><%= link_to '新規登録', new_user_path, class: 'btn btn-success me-3' %></li>
-        <li><%= link_to 'ログイン', login_path, class: 'nav-link' %></li>
-      <% end %>
-    </ul>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav ms-auto">
+        <% if logged_in? %>
+          <li><%= link_to 'ダッシュボード', dashboard_path, class: 'nav-link' %></li>
+          <li><%= link_to '研究ノート', notes_path, class: 'nav-link' %></li>
+          <li><%= link_to '保有銘柄', possessions_path, class: 'nav-link' %></li>
+          <li class="dropdown">
+            <a href="#" class="nav-link header-myicon" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <% if current_user.avatar.attached? %>
+                <%= image_tag current_user.avatar, alt: 'プロフィール画像', class: 'rounded-circle', width: '50' %>
+              <% else %>
+                <%= image_tag 'https://placehold.jp/150x150.png', alt: 'プロフィール画像', class: 'rounded-circle', width: '50' %>
+              <% end %>
+            </a>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+              <li><%= link_to 'マイページ', mypage_account_path, class: 'dropdown-item' %></li>
+              <li><hr class="dropdown-divider"></li>
+              <li><%= link_to '通知', '#', class: 'dropdown-item disabled' %></li>
+              <li><hr class="dropdown-divider"></li>
+              <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: 'dropdown-item' %></li>
+            </ul>
+          </li>
+        <% else %>
+          <li><%= link_to '新規登録', new_user_path, class: 'btn btn-success me-3' %></li>
+          <li><%= link_to 'ログイン', login_path, class: 'nav-link' %></li>
+        <% end %>
+      </ul>
+    </div>
   </div>
 </header>


### PR DESCRIPTION
# Issue
#46
# 概要
ヘッダーメニューの改善。
元々はサイドメニューにしようかと思っていたが、今のままヘッダーにメニューをまとめていいんじゃ無いかという結論になった。
わざわざ２箇所に分けるより、まとめていた方がわかりやすいと思う。

ログアウトボタンが表に出ていると押し間違えがありそうなので、マイページ・通知・ログアウトボタンをドロップダウンメニューにし、よくあるようなユーザーのアイコンを押すと出てくるスタイルにした。
