### PR TITLE
Feature/add tag to notes

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -18,11 +18,17 @@
   list-style: none;
 }
 
-.note_tags {
+.note_title {
+  color: black;
+  font-size: 2rem;
+}
+
+.notes_tags {
   display: flex;
   list-style-type: none;
   padding: 0;
   margin: 0;
+  color: black;
 }
 
 .flextextarea {

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -24,7 +24,7 @@ class NotesController < ApplicationController
   def create
     @note = current_user.notes.build(note_params)
     tags = params[:note][:tags].split(',')
-    
+
     if @note.save
       @note.save_notes_tags(tags)
       redirect_to note_url(@note), success: "ノート「#{@note.title}」を作成しました。"
@@ -32,11 +32,11 @@ class NotesController < ApplicationController
       render :new, status: :unprocessable_entity
     end
   end
-  
+
   def update
     @note = current_user.notes.find(params[:id])
     tags = params[:note][:tags].split(',')
-    
+
     if @note.update(note_params)
       @note.save_notes_tags(tags)
       flash.now[:success] = "ノート「#{@note.title}」を更新しました。"

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,6 +1,11 @@
 class NotesController < ApplicationController
   def index
-    @notes = current_user.notes
+    if params[:tag]
+      @tag = Tag.find_by(name: params[:tag])
+      @notes = @tag.notes.where(user_id: current_user.id)
+    else
+      @notes = current_user.notes
+    end
   end
 
   def show

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -13,22 +13,27 @@ class NotesController < ApplicationController
 
   def edit
     @note = current_user.notes.find(params[:id])
+    @tags = @note.tags.pluck(:name)
   end
 
   def create
     @note = current_user.notes.build(note_params)
-
+    tags = params[:note][:tags].split(',')
+    
     if @note.save
+      @note.save_notes_tags(tags)
       redirect_to note_url(@note), success: "ノート「#{@note.title}」を作成しました。"
     else
       render :new, status: :unprocessable_entity
     end
   end
-
+  
   def update
     @note = current_user.notes.find(params[:id])
-
+    tags = params[:note][:tags].split(',')
+    
     if @note.update(note_params)
+      @note.save_notes_tags(tags)
       flash.now[:success] = "ノート「#{@note.title}」を更新しました。"
     else
       render :edit, status: :unprocessable_entity

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -6,6 +6,21 @@ class Note < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :private, presence: true
+
+  def save_notes_tags(tags)
+    current_tags = self.tags.pluck(:name)
+    old_tags = current_tags - tags
+    new_tags = tags - current_tags
+
+    old_tags.each do |old_name|
+      self.tags.delete(Tag.find_by(name: old_name))
+    end
+
+    new_tags.each do |new_name|
+      notes_tag = Tag.find_or_create_by(name: new_name)
+      self.tags << notes_tag
+    end
+  end
 end
 
 # == Schema Information

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,6 +1,8 @@
 class Note < ApplicationRecord
   belongs_to :user
   has_many :note_blocks, dependent: :destroy
+  has_many :notes_tags, dependent: :destroy
+  has_many :tags, through: :notes_tags
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :private, presence: true

--- a/app/models/notes_tag.rb
+++ b/app/models/notes_tag.rb
@@ -1,6 +1,8 @@
 class NotesTag < ApplicationRecord
   belongs_to :tag
   belongs_to :note
+
+  validates :tag_id, uniqueness: { scope: :note_id }
 end
 
 # == Schema Information
@@ -15,8 +17,9 @@ end
 #
 # Indexes
 #
-#  index_notes_tags_on_note_id  (note_id)
-#  index_notes_tags_on_tag_id   (tag_id)
+#  index_notes_tags_on_note_id             (note_id)
+#  index_notes_tags_on_tag_id              (tag_id)
+#  index_notes_tags_on_tag_id_and_note_id  (tag_id,note_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/notes_tag.rb
+++ b/app/models/notes_tag.rb
@@ -2,3 +2,24 @@ class NotesTag < ApplicationRecord
   belongs_to :tag
   belongs_to :note
 end
+
+# == Schema Information
+#
+# Table name: notes_tags
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  note_id    :bigint           not null
+#  tag_id     :bigint           not null
+#
+# Indexes
+#
+#  index_notes_tags_on_note_id  (note_id)
+#  index_notes_tags_on_tag_id   (tag_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (note_id => notes.id)
+#  fk_rails_...  (tag_id => tags.id)
+#

--- a/app/models/notes_tag.rb
+++ b/app/models/notes_tag.rb
@@ -1,0 +1,4 @@
+class NotesTag < ApplicationRecord
+  belongs_to :tag
+  belongs_to :note
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,7 @@
 class Tag < ApplicationRecord
+  has_many :notes_tags, dependent: :destroy
+  has_many :notes, through: :notes_tags
+
   validates :name, presence: true, uniqueness: true, length: { maximum: 15 }
 end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,16 @@
 class Tag < ApplicationRecord
 end
+
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :bigint           not null, primary key
+#  name       :string(15)       not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_tags_on_name  (name) UNIQUE
+#

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,5 @@
 class Tag < ApplicationRecord
+  validates :name, presence: true, uniqueness: true, length: { maximum: 15 }
 end
 
 # == Schema Information

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -1,15 +1,24 @@
 <div class="row card-body border-bottom">
-  <div class="col text-3">
-    <%= link_to note.title, note_path(note) %>
+  <div class="col d-flex">
+    <%= link_to note.title, note_path(note), class: 'note_title' %>
+    <div class="ms-auto">
+      作成日時:<%= note.created_at.strftime('%Y/%m/%d %H:%M:%S') %><br>
+      更新日時:<%= note.updated_at.strftime('%Y/%m/%d %H:%M:%S') %>
+    </div>
   </div>
-  <div class="col">
-    <ul class="note_tags">
-      <li class="me-1">タグ１</li>
-      <li class="me-1">タグ２</li>
-      <li class="me-1">タグ３</li>
-    </ul>
-  </div>
-  <div class="col">
-    作成日時:<%= note.created_at.strftime('%Y/%m/%d %H:%M:%S') %>
+  <div class="row">
+    <div class="col">
+      <% if note.tags.any? %>
+        <ul class="notes_tags">
+          <% note.tags.each do |tag| %>
+            <li class="me-3">
+              <%= link_to tag.name, '#', class: 'link-secondary' %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <span class="text-secondary">タグなし</span>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -12,7 +12,7 @@
         <ul class="notes_tags">
           <% note.tags.each do |tag| %>
             <li class="me-3">
-              <%= link_to tag.name, '#', class: 'link-secondary' %>
+              <%= link_to tag.name, notes_path(tag: tag.name), class: 'link-secondary' %>
             </li>
           <% end %>
         </ul>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -2,8 +2,8 @@
   <hr>
   <%= bootstrap_form_with model: @note do |f| %>
     <%= f.text_field :title, maxlength: 50, help: 'タイトルは50文字まで入力できます。', placeholder: 'ここにタイトルを入力' %>
+    <%= f.text_field :tags, value: @tags.join(','), help: 'タグは,区切りで複数設定可能です', placeholder: '例)雑記,銘柄分析,AAPL,etc...' %>
     <%= f.submit class: 'btn btn-sm btn-primary me-3' %>
     <%= link_to 'キャンセル', @note, class: 'btn btn-sm btn-outline-secondary' %>
   <% end %>
-  <hr>
 <% end %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -9,6 +9,7 @@
       </div>
       <%= bootstrap_form_with model: @note do |f| %>
         <%= f.text_field :title, maxlength: 50, help: 'タイトルは50文字まで入力できます。', placeholder: 'ここにタイトルを入力' %>
+        <%= f.text_field :tags, value: nil, help: 'タグは,区切りで複数設定可能です', placeholder: '例)雑記,銘柄分析,AAPL,etc...' %>
         <%= f.submit '作成する', class: 'btn btn-primary' %>
       <% end %>
     </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -28,7 +28,7 @@
         <ul class="notes_tags">
           <% @note.tags.each do |tag| %>
             <li class="me-3">
-              <%= link_to tag.name, '#', class: 'link-secondary' %>
+              <%= link_to tag.name, notes_path(tag: tag.name), class: 'link-secondary' %>
             </li>
           <% end %>
         </ul>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -14,12 +14,28 @@
       <%= @note.user.username %>
     </div>
     <%= turbo_frame_tag @note do %>
-      <div class="h2">
-        <%= @note.title %>
-        <%= '(非公開)' if @note.private %>
+      <div class="col d-flex">
+        <div class="note_title">
+          <%= @note.title %>
+          <%= '(非公開)' if @note.private %>
+        </div>
+        <div class="ms-auto">
+          作成日時:<%= @note.created_at.strftime('%Y/%m/%d %H:%M:%S') %><br>
+          更新日時:<%= @note.updated_at.strftime('%Y/%m/%d %H:%M:%S') %>
+        </div>
       </div>
+      <% if @note.tags.any? %>
+        <ul class="notes_tags">
+          <% @note.tags.each do |tag| %>
+            <li class="me-3">
+              <%= link_to tag.name, '#', class: 'link-secondary' %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <span class="text-secondary">タグなし</span>
+      <% end %>
     <% end %>
-    <%= @note.created_at.strftime('%Y/%m/%d %H:%M:%S') %>
 
     <hr>
 

--- a/app/views/notes/update.turbo_stream.erb
+++ b/app/views/notes/update.turbo_stream.erb
@@ -1,8 +1,25 @@
 <%= turbo_stream.update dom_id(@note) do %>
-  <div class="h2">
-    <%= @note.title %>
-    <%= '(非公開)' if @note.private %>
+  <div class="col d-flex">
+    <div class="note_title">
+      <%= @note.title %>
+      <%= '(非公開)' if @note.private %>
+    </div>
+    <div class="ms-auto">
+      作成日時:<%= @note.created_at.strftime('%Y/%m/%d %H:%M:%S') %><br>
+      更新日時:<%= @note.updated_at.strftime('%Y/%m/%d %H:%M:%S') %>
+    </div>
   </div>
+  <% if @note.tags.any? %>
+    <ul class="notes_tags">
+      <% @note.tags.each do |tag| %>
+        <li class="me-3">
+          <%= link_to tag.name, '#', class: 'link-secondary' %>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <span class="text-secondary">タグなし</span>
+  <% end %>
 <% end %>
 
 <%= turbo_stream.update 'flash' do %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -28,3 +28,4 @@ ja:
       note:
         title: タイトル
         private: プライベート
+        tags: タグ

--- a/db/migrate/20230806133255_create_tags.rb
+++ b/db/migrate/20230806133255_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tags do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230806133255_create_tags.rb
+++ b/db/migrate/20230806133255_create_tags.rb
@@ -1,9 +1,10 @@
 class CreateTags < ActiveRecord::Migration[7.0]
   def change
     create_table :tags do |t|
-      t.string :name
+      t.string :name, null: false, limit: 15
 
       t.timestamps
+      t.index :name, unique: true
     end
   end
 end

--- a/db/migrate/20230806143150_create_notes_tags.rb
+++ b/db/migrate/20230806143150_create_notes_tags.rb
@@ -1,0 +1,10 @@
+class CreateNotesTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :notes_tags do |t|
+      t.references :tag, null: false, foreign_key: true
+      t.references :note, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230806143150_create_notes_tags.rb
+++ b/db/migrate/20230806143150_create_notes_tags.rb
@@ -5,6 +5,7 @@ class CreateNotesTags < ActiveRecord::Migration[7.0]
       t.references :note, null: false, foreign_key: true
 
       t.timestamps
+      t.index [:tag_id, :note_id], unique: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_06_133255) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_06_143150) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,6 +58,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_06_133255) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_notes_on_user_id"
+  end
+
+  create_table "notes_tags", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.bigint "note_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["note_id"], name: "index_notes_tags_on_note_id"
+    t.index ["tag_id"], name: "index_notes_tags_on_tag_id"
   end
 
   create_table "possessions", force: :cascade do |t|
@@ -129,6 +138,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_06_133255) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "note_blocks", "notes"
   add_foreign_key "notes", "users"
+  add_foreign_key "notes_tags", "notes"
+  add_foreign_key "notes_tags", "tags"
   add_foreign_key "possessions", "stocks"
   add_foreign_key "possessions", "users"
   add_foreign_key "prices", "stocks"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_24_070320) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_06_133255) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -94,6 +94,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_24_070320) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_stocks_on_code", unique: true
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", limit: 15, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "total_assets", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -66,6 +66,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_06_143150) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["note_id"], name: "index_notes_tags_on_note_id"
+    t.index ["tag_id", "note_id"], name: "index_notes_tags_on_tag_id_and_note_id", unique: true
     t.index ["tag_id"], name: "index_notes_tags_on_tag_id"
   end
 

--- a/spec/factories/notes_tags.rb
+++ b/spec/factories/notes_tags.rb
@@ -17,8 +17,9 @@ end
 #
 # Indexes
 #
-#  index_notes_tags_on_note_id  (note_id)
-#  index_notes_tags_on_tag_id   (tag_id)
+#  index_notes_tags_on_note_id             (note_id)
+#  index_notes_tags_on_tag_id              (tag_id)
+#  index_notes_tags_on_tag_id_and_note_id  (tag_id,note_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/factories/notes_tags.rb
+++ b/spec/factories/notes_tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :notes_tag do
+    tag { nil }
+    note { nil }
+  end
+end

--- a/spec/factories/notes_tags.rb
+++ b/spec/factories/notes_tags.rb
@@ -4,3 +4,24 @@ FactoryBot.define do
     note { nil }
   end
 end
+
+# == Schema Information
+#
+# Table name: notes_tags
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  note_id    :bigint           not null
+#  tag_id     :bigint           not null
+#
+# Indexes
+#
+#  index_notes_tags_on_note_id  (note_id)
+#  index_notes_tags_on_tag_id   (tag_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (note_id => notes.id)
+#  fk_rails_...  (tag_id => tags.id)
+#

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    name { "MyString" }
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :tag do
-    name { "MyString" }
+    name { 'MyString' }
   end
 end
 

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -3,3 +3,17 @@ FactoryBot.define do
     name { "MyString" }
   end
 end
+
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :bigint           not null, primary key
+#  name       :string(15)       not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_tags_on_name  (name) UNIQUE
+#

--- a/spec/models/notes_tag_spec.rb
+++ b/spec/models/notes_tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe NotesTag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/notes_tag_spec.rb
+++ b/spec/models/notes_tag_spec.rb
@@ -3,3 +3,24 @@ require 'rails_helper'
 RSpec.describe NotesTag, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end
+
+# == Schema Information
+#
+# Table name: notes_tags
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  note_id    :bigint           not null
+#  tag_id     :bigint           not null
+#
+# Indexes
+#
+#  index_notes_tags_on_note_id  (note_id)
+#  index_notes_tags_on_tag_id   (tag_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (note_id => notes.id)
+#  fk_rails_...  (tag_id => tags.id)
+#

--- a/spec/models/notes_tag_spec.rb
+++ b/spec/models/notes_tag_spec.rb
@@ -16,8 +16,9 @@ end
 #
 # Indexes
 #
-#  index_notes_tags_on_note_id  (note_id)
-#  index_notes_tags_on_tag_id   (tag_id)
+#  index_notes_tags_on_note_id             (note_id)
+#  index_notes_tags_on_tag_id              (tag_id)
+#  index_notes_tags_on_tag_id_and_note_id  (tag_id,note_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe Tag, type: :model do
       expect(tag.errors[:name]).to include('はすでに存在します')
     end
 
-    it 'タグ名は15文字以内であること' do
+    it 'タグ名は15文字以内であれば登録できる' do
       tag = build(:tag, name: 'a' * 15)
       tag.valid?
       expect(tag.errors[:name]).not_to include('は15文字以内で入力してください')
+    end
 
+    it 'タグ名は16文字以上であれば登録できない' do
       tag = build(:tag, name: 'a' * 16)
       tag.valid?
       expect(tag.errors[:name]).to include('は15文字以内で入力してください')

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -3,3 +3,17 @@ require 'rails_helper'
 RSpec.describe Tag, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end
+
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :bigint           not null, primary key
+#  name       :string(15)       not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_tags_on_name  (name) UNIQUE
+#

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,7 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe Tag, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    it 'タグ名は必須であること' do
+      tag = build(:tag, name: nil)
+      tag.valid?
+      expect(tag.errors[:name]).to include('を入力してください')
+    end
+
+    it 'タグ名は一意であること' do
+      create(:tag, name: 'tag')
+      tag = build(:tag, name: 'tag')
+      tag.valid?
+      expect(tag.errors[:name]).to include('はすでに存在します')
+    end
+
+    it 'タグ名は15文字以内であること' do
+      tag = build(:tag, name: 'a' * 15)
+      tag.valid?
+      expect(tag.errors[:name]).not_to include('は15文字以内で入力してください')
+
+      tag = build(:tag, name: 'a' * 16)
+      tag.valid?
+      expect(tag.errors[:name]).to include('は15文字以内で入力してください')
+    end
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
# Issue
#47
# 概要
ノートにタグ付け機能をつける。
ノートの作成時と編集時にタグを設定できるようにした。
タグはカンマ区切りで設定可能で一つのタグは30文字まで使用できる。
タグはノート名の下に表示し、タグのリンクをクリックすることで、そのタグがついたノートだけを表示することができる。
