### PR TITLE
研究ノートの公開機能を実装

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -20,7 +20,12 @@
 
 .note_title {
   color: black;
-  font-size: 2rem;
+  font-size: 1.5rem;
+}
+
+.note_title_other {
+  color: black;
+  font-size: 1.2rem;
 }
 
 .notes_tags {

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -2,14 +2,18 @@ class NotesController < ApplicationController
   def index
     if params[:tag]
       @tag = Tag.find_by(name: params[:tag])
-      @notes = @tag.notes.where(user_id: current_user.id)
+      @own_notes = @tag.notes.where(user_id: current_user.id)
+      @other_persons_notes = @tag.notes.where(private: false) - @own_notes
     else
-      @notes = current_user.notes
+      @own_notes = current_user.notes
+      @other_persons_notes = Note.where(private: false) - @own_notes
     end
   end
 
   def show
-    @note = current_user.notes.find(params[:id])
+    @note = Note.find(params[:id])
+    # ノートが非公開かつ自身のものでない場合は表示させない
+    redirect_to notes_url if @note.private && !current_user.own?(@note)
   end
 
   def new

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -18,7 +18,6 @@ class NotesController < ApplicationController
 
   def edit
     @note = current_user.notes.find(params[:id])
-    @tags = @note.tags.pluck(:name)
   end
 
   def create
@@ -55,6 +54,6 @@ class NotesController < ApplicationController
   private
 
   def note_params
-    params.require(:note).permit(:title)
+    params.require(:note).permit(:title, :private)
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -5,7 +5,7 @@ class Note < ApplicationRecord
   has_many :tags, through: :notes_tags
 
   validates :title, presence: true, length: { maximum: 50 }
-  validates :private, presence: true
+  validates :private, inclusion: [true, false]
 
   def save_notes_tags(tags)
     current_tags = self.tags.pluck(:name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,10 @@ class User < ApplicationRecord
     today_record = self.total_assets.find_or_create_by(date: Time.zone.today)
     today_record.update(price: total_asset) if today_record.price != total_asset
   end
+
+  def own?(object)
+    self.id == object.user_id
+  end
 end
 
 # == Schema Information

--- a/app/views/note_blocks/_note_block.html.erb
+++ b/app/views/note_blocks/_note_block.html.erb
@@ -3,9 +3,11 @@
     <div class="d-block" id="<%= note_block.index %>">
       <%= markdown(note_block.content) %>
     </div>
-    <div class="ms-auto">
-      <%= link_to '編集', edit_note_note_block_path(note_block), class: 'btn btn-primary' %>
-      <%= link_to '削除', note_note_block_path(@note, note_block), data: { turbo_method: :delete }, class: 'btn btn-danger' %>
-    </div>
+    <% if current_user.own?(@note) %>
+      <div class="ms-auto">
+        <%= link_to '編集', edit_note_note_block_path(note_block), class: 'btn btn-primary' %>
+        <%= link_to '削除', note_note_block_path(@note, note_block), data: { turbo_method: :delete }, class: 'btn btn-danger' %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/notes/_other_persons_note.html.erb
+++ b/app/views/notes/_other_persons_note.html.erb
@@ -1,0 +1,26 @@
+<div class="row card-body border-bottom">
+  <div class="col">
+    <%= link_to other_persons_note.title, note_path(other_persons_note), class: 'note_title_other' %>
+  </div>
+  <div class="row">
+    <div class="col">
+      <% if other_persons_note.tags.any? %>
+        <ul class="notes_tags">
+          <% other_persons_note.tags.each do |tag| %>
+            <li class="me-3">
+              <%= link_to tag.name, notes_path(tag: tag.name), class: 'link-secondary' %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <span class="text-secondary">タグなし</span>
+      <% end %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      作成日時:<%= other_persons_note.created_at.strftime('%Y/%m/%d %H:%M:%S') %><br>
+      更新日時:<%= other_persons_note.updated_at.strftime('%Y/%m/%d %H:%M:%S') %>
+    </div>
+  </div>
+</div>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -2,7 +2,8 @@
   <hr>
   <%= bootstrap_form_with model: @note do |f| %>
     <%= f.text_field :title, maxlength: 50, help: 'タイトルは50文字まで入力できます。', placeholder: 'ここにタイトルを入力' %>
-    <%= f.text_field :tags, value: @tags.join(','), help: 'タグは,区切りで複数設定可能です。一つのタグは30文字まで設定可能です(30文字を超えた部分は無視されます)。', placeholder: '例)雑記,銘柄分析,AAPL,etc...' %>
+    <%= f.text_field :tags, value: @note.tags.pluck(:name).join(','), help: 'タグは,区切りで複数設定可能です。一つのタグは30文字まで設定可能です(30文字を超えた部分は無視されます)。', placeholder: '例)雑記,銘柄分析,AAPL,etc...' %>
+    <%= f.check_box :private %>
     <%= f.submit class: 'btn btn-sm btn-primary me-3' %>
     <%= link_to 'キャンセル', @note, class: 'btn btn-sm btn-outline-secondary' %>
   <% end %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,13 +1,30 @@
-<div class="col-md-8">
+<div class="col-md-9">
   <h1 class="text-center mb-5">研究ノート</h1>
   <%= link_to '＋ノートを作成', new_note_path, class: 'btn btn-primary mb-3' %>
-  <div class="card shadow-sm">
-    <% if @notes.blank? %>
-      <div class="card-body text-center">
-        まだノートがありません。ノートを作成ボタンから作成してみましょう！
+  <div class="row">
+    <div class="col-md-8">
+      自分が作成したノート
+      <div class="card shadow-sm">
+        <% if @own_notes.blank? %>
+          <div class="card-body text-center">
+            まだノートがありません。ノートを作成ボタンから作成してみましょう！
+          </div>
+        <% else %>
+          <%= render @own_notes %>
+        <% end %>
       </div>
-    <% else %>
-      <%= render @notes %>
-    <% end %>
+    </div>
+    <div class="col-md-4">
+      他のユーザーが作成したノート
+      <div class="card shadow-sm">
+        <% if @other_persons_notes.blank? %>
+          <div class="card-body text-center">
+            まだノートがありません。
+          </div>
+        <% else %>
+          <%= render partial: 'other_persons_note', collection: @other_persons_notes %>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,10 +1,12 @@
 <div class="col-md-8">
   <%= link_to '一覧', notes_path, class: 'nav-link' %>
   <div class="card card-body">
-    <div class="d-flex justify-content-end">
-      <%= link_to '編集', edit_note_path, data: { turbo_frame: dom_id(@note) }, class: 'btn btn-primary me-3' %>
-      <%= link_to '削除', @note, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-danger' %>
-    </div>
+    <% if current_user.own?(@note) %>
+      <div class="d-flex justify-content-end">
+        <%= link_to '編集', edit_note_path, data: { turbo_frame: dom_id(@note) }, class: 'btn btn-primary me-3' %>
+        <%= link_to '削除', @note, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-danger' %>
+      </div>
+    <% end %>
     <div class="my-3">
       <% if @note.user.avatar.attached? %>
         <%= image_tag @note.user.avatar, alt: 'プロフィール画像', class: 'rounded-circle', width: '50' %>
@@ -42,7 +44,7 @@
     <div class="row">
       <div class="col">
         <%= render @note.note_blocks.order(index: :asc) %>
-        <%= render 'note_blocks/form' %>
+        <%= render 'note_blocks/form' if current_user.own?(@note) %>
       </div>
     </div>
   </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -27,5 +27,5 @@ ja:
         category: 分類
       note:
         title: タイトル
-        private: プライベート
+        private: 非公開
         tags: タグ


### PR DESCRIPTION
# Issue
#53 
# 概要
自身が作成した研究ノートを、他のユーザーへ公開することを可能にした。
ノート作成後、編集画面から非公開設定を外すことで公開される。
公開されたノートは、アプリにログインしている他のユーザーが閲覧することができる。
研究ノートの一覧ページ(/notes)の右側に他のユーザーが公開したノートが表示される。

# 今後の課題
- 公開されたノートは未ログイン状態でも閲覧できていいかなと思っているので、未ログイン状態でのノート一覧への動線を作成する必要がある
- ノートの検索機能はノート名やタグで検索できるように強化したい。